### PR TITLE
Fix rpath and related tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ endif()
 SET(CMAKE_INSTALL_PREFIX ${EMAN_INSTALL_PREFIX} CACHE INTERNAL "installation prefix")
 MARK_AS_ADVANCED(CLEAR EMAN_INSTALL_PREFIX)
 
+set(CMAKE_INSTALL_RPATH ${EMAN_INSTALL_PREFIX}/lib)
+
 OPTION(ENABLE_AUTODOC "enable latex/doxygen document generation and etc. " OFF)
 
 OPTION(ENABLE_FFTW2 "enable fftw 2 support (LEGACY)" OFF)

--- a/ci_support/build_no_envars.sh
+++ b/ci_support/build_no_envars.sh
@@ -5,8 +5,7 @@ source ci_support/pre_build.sh
 prefix=$HOME/miniconda2/
 sp_dir=$prefix/lib/python2.7/site-packages
 
-cmake $src_dir   -DCMAKE_INSTALL_RPATH="$HOME/EMAN2/lib" \
-                    -DNUMPY_INCLUDE_PATH="$sp_dir/numpy/core/include" \
+cmake $src_dir   -DNUMPY_INCLUDE_PATH="$sp_dir/numpy/core/include" \
                     -DBOOST_INCLUDE_PATH="$prefix/include" \
                     -DBOOST_LIBRARY="$prefix/lib/libboost_python.${suffix}" \
                     -DFFTW3_INCLUDE_PATH="$prefix/include" \


### PR DESCRIPTION
Tests with no envars set are supposed to test local development environments where builds are simply done with `cmake && make && make install`. For cmake to work automatically paths for include directories and libraries are passed through command-line to ensure cmake finds them. Besides the mentioned path variables, `CMAKE_INSTALL_RPATH` was also passed. That, undesirably, fixed the RPATH even if it was broken in CMakeLists. Here, that command-line argument is removed and tests on CircleCI and TravisCI are expected to fail to catch the RPATH problem. Then, it is fixed in CMakeLists and tests are expected to pass.