### PR TITLE
Add conda recipe for MacOSX and Linux

### DIFF
--- a/recipes/eman/build.sh
+++ b/recipes/eman/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+build_dir="${SRC_DIR}/../build_eman"
+
+rm -rf $build_dir
+mkdir -p $build_dir
+cd $build_dir
+
+cmake $SRC_DIR
+
+make -j${CPU_COUNT}
+make install

--- a/recipes/eman/meta.yaml
+++ b/recipes/eman/meta.yaml
@@ -8,7 +8,7 @@ source:
 requirements:
     {% set reqs_common = [
             "python 2.7.*",
-            "boost 1.63.*",
+            "boost 1.61.*",
             "fftw",
             "numpy",
             "ftgl",

--- a/recipes/eman/meta.yaml
+++ b/recipes/eman/meta.yaml
@@ -38,6 +38,5 @@ requirements:
         - matplotlib
         - ipython
         - pyqt 4.*
-        - pyopengl
+        - pyopengl 3.1.0
         - theano
-        - scipy

--- a/recipes/eman/meta.yaml
+++ b/recipes/eman/meta.yaml
@@ -6,37 +6,33 @@ source:
     path: {{ RECIPE_DIR }}/../..
 
 requirements:
+    {% set reqs_common = [
+            "python 2.7.*",
+            "boost 1.63.*",
+            "fftw",
+            "numpy",
+            "ftgl",
+            "freetype",
+            "gsl",
+            "hdf5",
+            "jpeg",
+            "libtiff",
+            "libpng",
+            "szip",  # [win]
+            "zlib",
+    ] %}
+    
     build:
         - cmake
         
-        - python 2.7.*
-        - boost 1.63*
-        - fftw
-        - numpy
-        - ftgl
-        - freetype
-        - gsl
-        - hdf5
-        - jpeg
-        - libtiff
-        - libpng
-        - szip  # [win]
-        - zlib
+        {% for req in reqs_common %}
+        - {{ req }}
+        {% endfor %}
     
     run:
-        - python 2.7.*
-        - boost 1.63*
-        - fftw
-        - numpy
-        - ftgl
-        - freetype
-        - gsl
-        - hdf5
-        - jpeg
-        - libtiff
-        - libpng
-        - szip  # [win]
-        - zlib
+        {% for req in reqs_common %}
+        - {{ req }}
+        {% endfor %}
         
         - bsddb  # [not win]
         - matplotlib

--- a/recipes/eman/meta.yaml
+++ b/recipes/eman/meta.yaml
@@ -18,12 +18,12 @@ requirements:
             "jpeg",
             "libtiff",
             "libpng",
-            "szip",  # [win]
             "zlib",
     ] %}
     
     build:
         - cmake
+        - szip  # [win]
         
         {% for req in reqs_common %}
         - {{ req }}
@@ -34,6 +34,7 @@ requirements:
         - {{ req }}
         {% endfor %}
         
+        - szip  # [win]
         - bsddb  # [not win]
         - matplotlib
         - ipython


### PR DESCRIPTION
This recipe can be used to build from source using `conda-build`. The simplest sequence of commands would be

```
$ conda build <path-to-eman2-source>/recipes/eman
$ conda install eman2 --use-local
```

This is how eman binary distributions are built. The only difference is instead of `conda-install`, the following command is run

`constructor <path to construct.yaml>`