### PR TITLE
fix shrinks1

### DIFF
--- a/programs/e2refinemulti.py
+++ b/programs/e2refinemulti.py
@@ -458,7 +458,7 @@ Based on your requested resolution and box-size, modified by --speed, I will use
 		if nx>=256 : shrinks1="--shrinks1 4"
 		elif nx>=96: shrinks1="--shrinks1 2"
 		else : shrinks1=""
-
+        else : shrinks1="--shrinks1 {}".format(options.shrinks1) #must pass shrinks1 to e2simmx2stage
 	if options.classaligncmp==None :
 		options.classaligncmp="ccc"
 


### PR DESCRIPTION
currently, specifying --shrinks1 causes error
  File "/home/kaelber/EMAN2/bin/e2refinemulti.py", line 595, in main
    shrinks1=shrinks1,shrink=shrink,prefilt=prefilt,simmask=simmask,verbose=verbose,parallel=parallel)
UnboundLocalError: local variable 'shrinks1' referenced before assignment
This is because the variable shrinks1 is only created if options.shrinks1==0 (the default) since the author forgot to define shrinks1 in an else condition. I tested the proposed change on sphere and it works.