### PR TITLE
Pull ftgl from new channel cryoem during tests on TravisCI and CircleCI

### DIFF
--- a/ci_support/pre_build.sh
+++ b/ci_support/pre_build.sh
@@ -14,7 +14,7 @@ conda config --set show_channel_urls true
 
 conda install --yes --quiet qt=4 pyqt=4
 conda install --yes --quiet -c conda-forge boost boost-cpp fftw
-conda install --yes --quiet -c jmbell ftgl
+conda install --yes --quiet -c cryoem ftgl
 conda install --yes --quiet bsddb freetype gsl hdf5 ipython jpeg libpng libtiff matplotlib numpy=1.11 pyopengl scikit-learn scipy theano tk cmake
 
 # Build and install eman2


### PR DESCRIPTION
With the availability of `ftgl` on `cryoem` channel, this PR switches to pull from the new channel. Local conda-builds should also make use of it with the following command.

`conda build <recipe-directory> -c defaults -c conda-forge -c cryoem`