### PR TITLE
Openmpi script and recipe for source installations on clusters

### DIFF
--- a/recipes/CMakeLists.txt
+++ b/recipes/CMakeLists.txt
@@ -1,3 +1,3 @@
-INSTALL(DIRECTORY fftw-mpi pydusa 
+INSTALL(DIRECTORY fftw-mpi pydusa openmpi
     DESTINATION    recipes
 )

--- a/recipes/eman/meta.yaml
+++ b/recipes/eman/meta.yaml
@@ -46,6 +46,8 @@ requirements:
         - pydusa  # [not win]
 
 test:
+  requires:
+    - openmpi              # [not win]
   imports:
     - mpi                  # [not win]
     - EMAN2

--- a/recipes/openmpi/build.sh
+++ b/recipes/openmpi/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [ $(uname) == Darwin ]; then
+    export LDFLAGS="$LDFLAGS -Wl,-rpath,$PREFIX/lib"
+fi
+
+export LIBRARY_PATH="$PREFIX/lib"
+
+./configure --prefix=$PREFIX \
+            --disable-dependency-tracking \
+            --enable-mpi-cxx \
+            --enable-mpi-fortran \
+            --with-wrapper-ldflags="-Wl,-rpath,$PREFIX/lib" \
+            --disable-dlopen
+
+make -j${CPU_COUNT}
+make install

--- a/recipes/openmpi/meta.yaml
+++ b/recipes/openmpi/meta.yaml
@@ -1,0 +1,50 @@
+{% set version = "2.0.2" %}
+{% set major = ".".join(version.split(".")[:2]) %}
+
+package:
+    name: openmpi
+    version: {{ version }}
+
+source:
+    fn: openmpi-{{ version }}.tar.bz2
+    url: https://www.open-mpi.org/software/ompi/v{{ major }}/downloads/openmpi-{{ version }}.tar.bz2
+    sha1: 80e39bc76ac2e3caf958a3db9985a9c81fddb8a6
+
+build:
+    number: 1
+    skip: True  # [win]
+
+requirements:
+    build:
+        - gcc  # [not win]
+        - perl 5.22.2.1
+        - toolchain
+    run:
+        - libgcc  # [linux]
+        - libgfortran  # [osx]
+
+test:
+    requires:
+        - gcc  # [not win]
+    files:
+        - tests/helloworld.c
+        - tests/helloworld.cxx
+        - tests/helloworld.f
+        - tests/helloworld.f90
+    commands:
+        - conda inspect objects openmpi  # [osx]
+        - conda inspect linkages openmpi  # [not win]
+
+
+about:
+    home: http://www.open-mpi.org/
+    license: BSD 3-Clause
+    license_family: BSD
+    license_file: LICENSE
+    summary: 'An open source Message Passing Interface implementation.'
+    description: |
+        The Open MPI Project is an open source Message Passing Interface
+        implementation that is developed and maintained by a consortium of academic,
+        research, and industry partners.
+    doc_url: https://www.open-mpi.org/doc/
+    dev_url: https://github.com/open-mpi/ompi

--- a/recipes/openmpi/run_test.sh
+++ b/recipes/openmpi/run_test.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+command -v ompi_info
+ompi_info
+
+command -v mpicc
+mpicc -show
+
+command -v mpicxx
+mpicxx -show
+
+command -v mpif90
+mpif90 -show
+
+command -v mpiexec
+if [[ "$(uname)" == "Darwin" ]]; then
+  MPIEXEC="mpiexec -mca plm isolated --allow-run-as-root"
+  $MPIEXEC --help
+else
+  # skip mpiexec tests on Linux due to conda-forge bug:
+  # https://github.com/conda-forge/conda-smithy/pull/337
+  MPIEXEC="echo SKIPPING mpiexec"
+fi
+
+pushd $RECIPE_DIR/tests
+
+mpicc helloworld.c -o helloworld_c
+$MPIEXEC -n 4 ./helloworld_c
+
+mpicxx helloworld.cxx -o helloworld_cxx
+$MPIEXEC -n 4 ./helloworld_cxx
+
+mpif77 helloworld.f -o helloworld_f
+$MPIEXEC -n 4 ./helloworld_f
+
+mpif90 helloworld.f90 -o helloworld_f90
+$MPIEXEC -n 4 ./helloworld_f90
+
+popd

--- a/recipes/openmpi/tests/helloworld.c
+++ b/recipes/openmpi/tests/helloworld.c
@@ -1,0 +1,19 @@
+#include <mpi.h>
+#include <stdio.h>
+
+int main(int argc, char *argv[])
+{
+  int provided, size, rank, len;
+  char name[MPI_MAX_PROCESSOR_NAME];
+
+  MPI_Init(&argc, &argv);
+
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Get_processor_name(name, &len);
+
+  printf("Hello, World! I am process %d of %d on %s.\n", rank, size, name);
+
+  MPI_Finalize();
+  return 0;
+}

--- a/recipes/openmpi/tests/helloworld.cxx
+++ b/recipes/openmpi/tests/helloworld.cxx
@@ -1,0 +1,22 @@
+#include <mpi.h>
+#include <iostream>
+
+int main(int argc, char *argv[])
+{
+  MPI::Init();
+
+  int size = MPI::COMM_WORLD.Get_size();
+  int rank = MPI::COMM_WORLD.Get_rank();
+  int len; char name[MPI_MAX_PROCESSOR_NAME];
+  MPI::Get_processor_name(name, len);
+
+  std::cout <<
+    "Hello, World! " <<
+    "I am process "  << rank <<
+    " of "           << size <<
+    " on  "          << name <<
+    "."              << std::endl;
+
+  MPI::Finalize();
+  return 0;
+}

--- a/recipes/openmpi/tests/helloworld.f
+++ b/recipes/openmpi/tests/helloworld.f
@@ -1,0 +1,21 @@
+      program main
+
+      include 'mpif.h'
+
+      integer ierr, rank, size, len
+      character name*(MPI_MAX_PROCESSOR_NAME)
+
+      call MPI_INIT(ierr)
+      call MPI_COMM_RANK(MPI_COMM_WORLD, rank, ierr)
+      call MPI_COMM_SIZE(MPI_COMM_WORLD, size, ierr)
+      call MPI_GET_PROCESSOR_NAME(name, len, ierr)
+
+      print '(2A,I2,A,I2,3A)',
+     &      'Hello, World! ',
+     &     'I am process ', rank,
+     &     ' of ', size,
+     &     ' on ', trim(name), '.'
+
+      call MPI_FINALIZE(ierr)
+
+      end

--- a/recipes/openmpi/tests/helloworld.f90
+++ b/recipes/openmpi/tests/helloworld.f90
@@ -1,0 +1,23 @@
+program main
+
+  use mpi
+  implicit none
+
+  integer :: provided,  ierr, size, rank, len
+  character (len=MPI_MAX_PROCESSOR_NAME) :: name
+
+  call MPI_Init(ierr)
+
+  call MPI_Comm_rank(MPI_COMM_WORLD, rank, ierr)
+  call MPI_Comm_size(MPI_COMM_WORLD, size, ierr)
+  call MPI_Get_processor_name(name, len, ierr)
+
+  write(*, '(2A,I2,A,I2,3A)') &
+       'Hello, World! ', &
+       'I am process ', rank, &
+       ' of ', size, &
+       ' on ', name(1:len), '.'
+
+  call MPI_Finalize(ierr)
+
+end program main

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,3 +1,3 @@
-INSTALL(PROGRAMS install_pydusa.sh uninstall_openmpi.sh
+INSTALL(PROGRAMS install_pydusa.sh uninstall_openmpi.sh build_and_install_openmpi.sh
     DESTINATION    utils
 )

--- a/utils/build_and_install_openmpi.sh
+++ b/utils/build_and_install_openmpi.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Builds and installs openmpi
+
+set -xe
+
+source activate root
+
+RECIPES_DIR=$(cd $(dirname $0)/../recipes && pwd -P)
+conda build ${RECIPES_DIR}/openmpi -c defaults -c conda-forge
+conda install openmpi --use-local --yes

--- a/utils/install_pydusa.sh
+++ b/utils/install_pydusa.sh
@@ -2,12 +2,12 @@
 
 set -xe
 
-source activate
+source activate root
 
-RECIPE_DIR="${CONDA_PREFIX}/recipes"
-conda build ${RECIPE_DIR}/fftw-mpi
-conda build ${RECIPE_DIR}/pydusa
+RECIPES_DIR=$(cd $(dirname $0)/../recipes && pwd -P)
+conda build ${RECIPES_DIR}/pydusa
+conda remove fftw-mpi --force --yes
 conda install pydusa --use-local --yes
+conda install fftw-mpi --use-local --yes
 
-# Cleanup
-conda build purge
+conda inspect linkages pydusa

--- a/utils/uninstall_openmpi.sh
+++ b/utils/uninstall_openmpi.sh
@@ -2,6 +2,6 @@
 
 set -x
 
-source activate
+source activate root
 
-conda remove openmpi pydusa fftw-mpi --force
+conda remove openmpi --force


### PR DESCRIPTION
**All of this is aimed to help with setting up eman on clusters.**

- Tweaks `openmpi` uninstallation, `fftw-mpi` and `pydusa` installation scripts.
- Adds a script to install `openmpi` from source and `openmpi` recipe.
