### PR TITLE
Add git commit hash to e2version output

### DIFF
--- a/programs/CMakeLists.txt
+++ b/programs/CMakeLists.txt
@@ -53,6 +53,7 @@ ENDIF(WIN32)
 # MESSAGE("Installed e2ctf_auto.py in bin manually (failed earlier for some reason.")
 
 string(TIMESTAMP EMAN_TIMESTAMP "%Y-%m-%d %H:%M")
+set(EMAN_TIMESTAMP "${EMAN_TIMESTAMP} - git_hash: $ENV{GIT_FULL_HASH}")
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/e2version.py.in
 				${CMAKE_INSTALL_PREFIX}/bin/e2version.py
 				)

--- a/programs/CMakeLists.txt
+++ b/programs/CMakeLists.txt
@@ -28,7 +28,7 @@ IF(WIN32)
 ENDIF(WIN32)
 
 string(TIMESTAMP EMAN_TIMESTAMP "%Y-%m-%d %H:%M")
-set(EMAN_GITHASH $ENV{GIT_FULL_HASH})
+string(SUBSTRING $ENV{GIT_FULL_HASH} 0 7 EMAN_GITHASH)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/e2version.py.in
 				${CMAKE_INSTALL_PREFIX}/bin/e2version.py
 				)

--- a/programs/CMakeLists.txt
+++ b/programs/CMakeLists.txt
@@ -53,7 +53,7 @@ ENDIF(WIN32)
 # MESSAGE("Installed e2ctf_auto.py in bin manually (failed earlier for some reason.")
 
 string(TIMESTAMP EMAN_TIMESTAMP "%Y-%m-%d %H:%M")
-set(EMAN_TIMESTAMP "${EMAN_TIMESTAMP} - git_hash: $ENV{GIT_FULL_HASH}")
+set(EMAN_GITHASH $ENV{GIT_FULL_HASH})
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/e2version.py.in
 				${CMAKE_INSTALL_PREFIX}/bin/e2version.py
 				)

--- a/programs/CMakeLists.txt
+++ b/programs/CMakeLists.txt
@@ -1,20 +1,9 @@
 FILE(GLOB e2programs "${CMAKE_CURRENT_SOURCE_DIR}/*.py")
 
-# MESSAGE("original pgm list: ${e2programs}")
-
 FILE(GLOB exclusion_list "e2plotFSC.py" "e2refine_evenodd.py" "e2refine_evenodd.py" "e2refmerge.py" "e2resolution.py" "e2montecarlorecon.py" "e2markbadparticles.py" "e22.py" "e2boxer21.py" "e2classesbyref.py" "e2ali2img.py" "e2avg_ffts.py" "e2fileinfo.py"  "e2flick.py" "e2findsubunit.py" "e2helical_recons.py" "e2modeleval.py" "e2preferences.py" "e2proc3d_huge.py" "e2scp.py" "e2tomoallvall.py" "e2tomoaverage.py" "e2tomohunter.py" "e2remoted.py" "e2tomosim.py")
 LIST(REMOVE_ITEM e2programs ${exclusion_list})
-#######MESSAGE(SEND_ERROR "${e2programs}")    #for debug purpose ######
-
-# MESSAGE("cut back pgm list: ${e2programs}")
-
-# SET(ED  $ENV{EMANDIR})
-# SET(E2D $ENV{EMAN2DIR})
-# SET(HOM $ENV{HOME})
 
 SET(DBG $ENV{DEBUG})
-
-# MESSAGE("envs: '${ED}' '${E2D}' '${HOM}' '${DBG}'")
 
 FOREACH(f ${e2programs})
 	IF(DBG MATCHES "y")
@@ -25,14 +14,6 @@ ENDFOREACH(f)
 INSTALL(PROGRAMS ${e2programs}
   DESTINATION    bin
 )
-
-#INSTALL(PROGRAMS    e2boxer.py 
-#                    e2version.py 
-#                    e2ctf.py 
-#                    e2history.py
-#                    #....
-#        DESTINATION bin
-#)
 
 IF(WIN32)
 	INSTALL(FILES e2boxer.py
@@ -45,12 +26,6 @@ IF(WIN32)
 		RENAME	e2display.pyw
 		)
 ENDIF(WIN32)
-
-# INSTALL(PROGRAMS e2ctf_auto.py
-#       DESTINATION bin
-#       )
-
-# MESSAGE("Installed e2ctf_auto.py in bin manually (failed earlier for some reason.")
 
 string(TIMESTAMP EMAN_TIMESTAMP "%Y-%m-%d %H:%M")
 set(EMAN_GITHASH $ENV{GIT_FULL_HASH})

--- a/programs/CMakeLists.txt
+++ b/programs/CMakeLists.txt
@@ -28,7 +28,7 @@ IF(WIN32)
 ENDIF(WIN32)
 
 string(TIMESTAMP EMAN_TIMESTAMP "%Y-%m-%d %H:%M")
-string(SUBSTRING $ENV{GIT_FULL_HASH} 0 7 EMAN_GITHASH)
+string(SUBSTRING "$ENV{GIT_FULL_HASH}" 0 7 EMAN_GITHASH)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/e2version.py.in
 				${CMAKE_INSTALL_PREFIX}/bin/e2version.py
 				)

--- a/programs/e2version.py.in
+++ b/programs/e2version.py.in
@@ -37,7 +37,7 @@ import platform
 from subprocess import *
 
 
-EMANVERSION="EMAN2 2.2"
+EMANVERSION="EMAN 2.2"
 DATESTAMP="@EMAN_TIMESTAMP@"
 GITHASH="@EMAN_GITHASH@"
 

--- a/programs/e2version.py.in
+++ b/programs/e2version.py.in
@@ -39,9 +39,10 @@ from subprocess import *
 
 EMANVERSION="EMAN 2.2"
 DATESTAMP="@EMAN_TIMESTAMP@"
+GITHASH="@EMAN_GITHASH@"
 
 def main():
-	print(EMANVERSION + ' (GITHUB: ' + DATESTAMP +')')
+	print(EMANVERSION + ' (GITHUB: ' + DATESTAMP + ' - commit: ' + GITHASH +')')
 
 	if sys.platform=='linux2':
 		print('Your EMAN2 is running on: {} {}'.format(platform.platform(), os.uname()[2], os.uname()[-1]))

--- a/programs/e2version.py.in
+++ b/programs/e2version.py.in
@@ -37,7 +37,7 @@ import platform
 from subprocess import *
 
 
-EMANVERSION="EMAN 2.2"
+EMANVERSION="EMAN2 2.2"
 DATESTAMP="@EMAN_TIMESTAMP@"
 GITHASH="@EMAN_GITHASH@"
 


### PR DESCRIPTION
Sample output when EMAN is built in an environment where environment variable `GIT_FULL_HASH` is set, e.g. during `conda-build`:

```
EMAN2 2.2 (GITHUB: 2017-05-29 00:39 - commit: 586ccb347d971987bead2b7b73574c03a780c273)
Your EMAN2 is running on: Mac OS 10.11.6 x86_64
Your Python version is: 2.7.13
```

Sample output when `GIT_FULL_HASH` is not set:

```
EMAN2 2.2 (GITHUB: 2017-05-29 00:39 - commit: )
Your EMAN2 is running on: Mac OS 10.11.6 x86_64
Your Python version is: 2.7.13
```