### PR TITLE
Fix DATESTAMP usage

### DIFF
--- a/programs/e2help.py
+++ b/programs/e2help.py
@@ -35,6 +35,7 @@
 # This program will provide a variety of EMAN2 help
 
 from EMAN2 import *
+import e2version
 from math import *
 import os
 import sys
@@ -134,7 +135,7 @@ act as a filter on the names of the algorithms."""
 		"quaternion":["Standard 4 component quaternion (e0,e1,e2,e3)","e0","FLOAT","e0","e1","FLOAT","e1","e2","FLOAT","e2","e3","FLOAT","e3"]}
 
 	elif args[0] in ("version"):
-	   print EMANVERSION + ' (CVS' + DATESTAMP +')'
+		e2version.main()
 	else:
 		print helpstring
 		print "unknown option:",args[0]

--- a/programs/e2help.py
+++ b/programs/e2help.py
@@ -134,7 +134,7 @@ act as a filter on the names of the algorithms."""
 		"quaternion":["Standard 4 component quaternion (e0,e1,e2,e3)","e0","FLOAT","e0","e1","FLOAT","e1","e2","FLOAT","e2","e3","FLOAT","e3"]}
 
 	elif args[0] in ("version"):
-	   print EMANVERSION + ' (CVS' + DATESTAMP[6:-2] +')' 
+	   print EMANVERSION + ' (CVS' + DATESTAMP +')'
 	else:
 		print helpstring
 		print "unknown option:",args[0]

--- a/programs/eman2.py
+++ b/programs/eman2.py
@@ -54,7 +54,7 @@ from emapplication import EMApp
 import os, json, re, glob, signal
 import subprocess
 
-helpstring+="\n\nYou are currently running %s (%s)"%(EMANVERSION,DATESTAMP[6:-2])
+helpstring+="\n\nYou are currently running %s (%s)"%(EMANVERSION,DATESTAMP)
 
 try:
 	if os.getenv("DISPLAY")==None : raise Exception


### PR DESCRIPTION
Before the fix:
---
```
$ eman2.py
...
...
You are currently running EMAN 2.2 (6-18 18:)
```

```
$ e2help.py version
EMAN 2.2 (CVS6-18 20:)
```

After the fix here:
---
```
$ eman2 .py
...
...
You are currently running EMAN 2.2 (2017-06-18 20:03)
```

```
$ e2help.py version
EMAN 2.2 (GITHUB: 2017-06-18 20:03)
Your EMAN2 is running on: Mac OS 10.11.6 x86_64
Your Python version is: 2.7.13
```