### PR TITLE
Regression tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -745,13 +745,15 @@ ADD_SUBDIRECTORY(doc)
 ADD_SUBDIRECTORY(images)
 ADD_SUBDIRECTORY(recipes)
 
-if("$ENV{CONDA_BUILD_STATE}" STREQUAL "BUILD" OR ENABLE_CONDA)
-	install(CODE "execute_process(
-					COMMAND ${CMAKE_COMMAND} -E create_symlink ${CONDA_PREFIX}/bin/e2version.py ${CONDA_SP_DIR}/e2version.py
-					COMMAND ${CMAKE_COMMAND} -E create_symlink ${CONDA_PREFIX}/bin/sxgui.py     ${CONDA_PREFIX}/bin/sphire
-					COMMAND ${CMAKE_COMMAND} -E create_symlink ${CONDA_PREFIX}/bin/sx.py        ${CONDA_PREFIX}/bin/sparx
-				 )"
-			)
+if(NOT WIN32)
+	if("$ENV{CONDA_BUILD_STATE}" STREQUAL "BUILD" OR ENABLE_CONDA)
+		install(CODE "execute_process(
+						COMMAND ${CMAKE_COMMAND} -E create_symlink ${CONDA_PREFIX}/bin/e2version.py ${CONDA_SP_DIR}/e2version.py
+						COMMAND ${CMAKE_COMMAND} -E create_symlink ${CONDA_PREFIX}/bin/sxgui.py     ${CONDA_PREFIX}/bin/sphire
+						COMMAND ${CMAKE_COMMAND} -E create_symlink ${CONDA_PREFIX}/bin/sx.py        ${CONDA_PREFIX}/bin/sparx
+					 )"
+				)
+	endif()
 endif()
 
 enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -770,7 +770,7 @@ add_custom_target(test-verbose
 
 function(add_test_wrapper name)
 	add_test(NAME ${name}
-			COMMAND nosetests ${EMAN_INSTALL_PREFIX}/test/rt/pyem/test_imageio.py:${name}
+			COMMAND nosetests ${EMAN_INSTALL_PREFIX}/test/rt/pyem/${name}
 			)
 endfunction()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -765,6 +765,17 @@ add_custom_target(test-verbose
 #		COMMAND ${CMAKE_CTEST_COMMAND} -V -C Release
 #		DEPENDS Tests
 #		)
+
+function(add_test_wrapper name)
+	add_test(NAME ${name}
+			COMMAND nosetests ${EMAN_INSTALL_PREFIX}/test/rt/pyem/test_imageio.py:${name}
+			)
+endfunction()
+
+add_test_wrapper(TestHdfIO.test_read_image)
+add_test_wrapper(TestHdfIO.test_write_image)
+add_test_wrapper(TestHdfIO.test_read_write_hdf)
+add_test_wrapper(TestPNGIO.test_write_png)
 # --------------------------------------------------------------------
 #set the list of unit test to run
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -772,10 +772,16 @@ function(add_test_wrapper name)
 			)
 endfunction()
 
-add_test_wrapper(TestHdfIO.test_read_image)
-add_test_wrapper(TestHdfIO.test_write_image)
-add_test_wrapper(TestHdfIO.test_read_write_hdf)
-add_test_wrapper(TestPNGIO.test_write_png)
+set(test_methods
+		TestHdfIO.test_read_image
+		TestHdfIO.test_write_image
+		TestHdfIO.test_read_write_hdf
+		TestPNGIO.test_write_png
+		)
+
+foreach(t ${test_methods})
+	add_test_wrapper(${t})
+endforeach()
 # --------------------------------------------------------------------
 #set the list of unit test to run
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -775,10 +775,10 @@ function(add_test_wrapper name)
 endfunction()
 
 set(test_methods
-		TestHdfIO.test_read_image
-		TestHdfIO.test_write_image
-		TestHdfIO.test_read_write_hdf
-		TestPNGIO.test_write_png
+		test_imageio.py:TestHdfIO.test_read_image
+		test_imageio.py:TestHdfIO.test_write_image
+		test_imageio.py:TestHdfIO.test_read_write_hdf
+		test_imageio.py:TestPNGIO.test_write_png
 		)
 
 foreach(t ${test_methods})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -754,16 +754,7 @@ if("$ENV{CONDA_BUILD_STATE}" STREQUAL "BUILD" OR ENABLE_CONDA)
 			)
 endif()
 
-ADD_CUSTOM_TARGET( unittest
-	DEPENDS	${TEST_RESULTS}
-)
-
-ADD_CUSTOM_COMMAND(
-	TARGET unittest
-	POST_BUILD
-	COMMAND python
-	ARGS ${EMAN_INSTALL_PREFIX}/test/rt/rt.py
-)
+enable_testing()
 
 #set the list of unit test to run
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -756,6 +756,16 @@ endif()
 
 enable_testing()
 
+add_custom_target(test-verbose
+		COMMAND ${CMAKE_COMMAND} -P cmake_install.cmake
+		COMMAND ${CMAKE_CTEST_COMMAND} -V -C Release
+		)
+
+#add_custom_target(test-verbose
+#		COMMAND ${CMAKE_CTEST_COMMAND} -V -C Release
+#		DEPENDS Tests
+#		)
+# --------------------------------------------------------------------
 #set the list of unit test to run
 #
 SET (TESTS

--- a/ci_support/build_no_envars.sh
+++ b/ci_support/build_no_envars.sh
@@ -35,6 +35,7 @@ cmake $src_dir   -DENABLE_CONDA=OFF \
 
 make
 make install
+make test-verbose
 
 export PREFIX="${HOME}"/EMAN2
 export SP_DIR="${PREFIX}"/lib

--- a/ci_support/build_no_envars.sh
+++ b/ci_support/build_no_envars.sh
@@ -35,7 +35,6 @@ cmake $src_dir   -DENABLE_CONDA=OFF \
 
 make
 make install
-make test-verbose
 
 export PREFIX="${HOME}"/EMAN2
 export SP_DIR="${PREFIX}"/lib
@@ -45,5 +44,7 @@ export PYTHONPATH="$SP_DIR:$PYTHONPATH"
 ln -s $PREFIX/bin/e2version.py $SP_DIR/e2version.py
 ln -s $PREFIX/bin/sxgui.py     $PREFIX/bin/sphire
 ln -s $PREFIX/bin/sx.py        $PREFIX/bin/sparx
+
+make test-verbose
 
 source $src_dir/ci_support/post_build.sh

--- a/ci_support/build_with_envars.sh
+++ b/ci_support/build_with_envars.sh
@@ -5,6 +5,7 @@ source ci_support/pre_build.sh
 cmake $src_dir -DENABLE_CONDA=ON
 make
 make install
+make test-verbose
 
 export PREFIX=$CONDA_PREFIX
 export SP_DIR=$(python -c "import site; print site.getsitepackages()[0]")

--- a/ci_support/pre_build.sh
+++ b/ci_support/pre_build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -x
+set -xe
 
 # Download and install Miniconda
 export MINICONDA_URL="https://repo.continuum.io/miniconda"

--- a/recipes/eman/bld.bat
+++ b/recipes/eman/bld.bat
@@ -15,3 +15,6 @@ if errorlevel 1 exit 1
 
 mklink "%SP_DIR%\\e2version.py" "%LIBRARY_BIN%\\e2version.py"
 if errorlevel 1 exit 1
+
+cmake --build "%builddir%" --config Release --target test-verbose
+if errorlevel 1 exit 1

--- a/recipes/eman/build.sh
+++ b/recipes/eman/build.sh
@@ -10,3 +10,4 @@ cmake $SRC_DIR
 
 make -j${CPU_COUNT}
 make install
+make test-verbose

--- a/rt/pyem/CMakeLists.txt
+++ b/rt/pyem/CMakeLists.txt
@@ -1,4 +1,4 @@
 FILE(GLOB testprograms "${CMAKE_CURRENT_SOURCE_DIR}/*.py")
 INSTALL(PROGRAMS ${testprograms}
-  DESTINATION    test/rt
+  DESTINATION    test/rt/pyem
 )


### PR DESCRIPTION
Adds some regression tests. Several PRs that refactor the build system massively are underway. It is crucial to have tests beyond simple build and install. This PR, currently, includes `hdf io` and `png io` tests which were helpful to catch some breakage introduced in the mentioned cmake PRs. Any suggestions for other tests that could be important to include here? There is a large collection of scripts in directory rt, https://github.com/cryoem/eman2/tree/master/rt. Please, note that not all of the scripts work at the moment, so including additional tests may require some fixing.

The tests can be run after `make install`, by running `make test` or `make test-verbose` on Unix-like systems. The tests are also added to all automated tests on the CI servers.