### PR TITLE
Reduce test output during `e2*.py -h` runs

### DIFF
--- a/ci_support/post_build.sh
+++ b/ci_support/post_build.sh
@@ -7,7 +7,6 @@ export PATH="$PREFIX/bin:$PATH"
 
 e2version.py
 e2speedtest.py
-e2display.py -h
 mpirun -n 4 $(which python) ${PREFIX}/examples/mpi_test.py
 cd ${src_dir}
 bash tests/run_prog_tests.sh

--- a/recipes/eman/meta.yaml
+++ b/recipes/eman/meta.yaml
@@ -79,7 +79,6 @@ test:
   commands:
     - e2version.py
     - e2speedtest.py
-    - e2display.py -h
     - test -f ${PREFIX}/examples/mpi_test.py                        # [not win]
     - mpirun -n 4 $(which python) ${PREFIX}/examples/mpi_test.py    # [not win]
     - if not exist %LIBRARY_PREFIX%\\examples\\mpi_test.py  exit 1  # [win]

--- a/tests/programs_to_test.txt
+++ b/tests/programs_to_test.txt
@@ -95,7 +95,6 @@ e2simmx2stage.py
 e2simmxxplor.py
 e2skelpath.py
 e2sparxtoeman.py
-e2speedtest.py
 e2spt_align.py
 e2spt_autoboxer.py
 e2spt_average.py

--- a/tests/run_prog_tests.sh
+++ b/tests/run_prog_tests.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 
+set -e
+
 MYDIR=$(cd $(dirname $0); pwd -P)
 progs_file=${MYDIR}/programs_to_test.txt
 progs=$(cat "${progs_file}")
-if [ $? -ne 0 ];then
-    exit 1
-fi
+
+set +e
 
 failed_progs=()
 for prog in ${progs[@]};do

--- a/tests/run_prog_tests.sh
+++ b/tests/run_prog_tests.sh
@@ -9,7 +9,7 @@ fi
 failed_progs=()
 for prog in ${progs[@]};do
     echo "Running: $prog -h"
-    $prog -h
+    $prog -h > /dev/null
     if [ $? -ne 0 ];then
         failed_progs+=($prog)
     fi

--- a/tests/run_prog_tests.sh
+++ b/tests/run_prog_tests.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-progs_file="tests/programs_to_test.txt"
-progs=$(cat ${progs_file})
+MYDIR=$(cd $(dirname $0); pwd -P)
+progs_file=${MYDIR}/programs_to_test.txt
+progs=$(cat "${progs_file}")
 if [ $? -ne 0 ];then
     exit 1
 fi

--- a/tests/run_prog_tests.sh
+++ b/tests/run_prog_tests.sh
@@ -17,6 +17,7 @@ for prog in ${progs[@]};do
     fi
 done
 
+echo
 echo "Total failed programs: ${#failed_progs[@]}"
 for prog in ${failed_progs[@]};do
     echo ${prog}


### PR DESCRIPTION
Redirects stdout output to `/dev/null` and leaves only stderr. Reduces test output and should help with looking through the logs for program failures.