### PR TITLE
Fix tests: pin conda-build=2

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ install:
     - conda install -n root --yes --quiet vs2008_express_vc_python_patch -c conda-forge
     - call setup_x64
 
-    - conda install --quiet --yes conda-build
+    - conda install --quiet --yes conda-build=2
     - conda update --yes --quiet conda -c defaults
 
     - conda info

--- a/ci_support/build_recipe.sh
+++ b/ci_support/build_recipe.sh
@@ -14,7 +14,7 @@ conda config --set show_channel_urls true
 
 export CPU_COUNT=2
 
-conda install conda-build -c defaults --yes --quiet
+conda install conda-build=2 -c defaults --yes --quiet
 
 if [ "$(uname -s)" != "Darwin" ];then
     conda build recipes/eman -c cryoem -c defaults -c conda-forge --numpy 1.8


### PR DESCRIPTION
`conda-build` has been updated and for some reason complains about dependencies:
`Unsatisfiable dependencies for platform osx-64: ['python']`
`Unsatisfiable dependencies for platform linux-64: ['numpy']`
`Unsatisfiable dependencies for platform win-64: ['python']`.

Pinning conda-build to previous major version for now.