### PR TITLE
Fix LST for Windows

### DIFF
--- a/libpyEM/EMAN2.py
+++ b/libpyEM/EMAN2.py
@@ -2077,7 +2077,7 @@ line length. Used when a line must be added in the middle of the file."""
 
 		self.ptr.seek(0)
 
-		tmpfile=file(self.path+".tmp","w")
+		tmpfile=file(self.path+".tmp","wb")
 		# copy the header lines
 		tmpfile.write(self.ptr.readline())
 		tmpfile.write(self.ptr.readline())
@@ -2110,7 +2110,7 @@ line length. Used when a line must be added in the middle of the file."""
 		# rename the temporary file over the original
 		os.unlink(self.path)
 		os.rename(self.path+".tmp",self.path)
-		self.ptr=file(self.path,"r+")
+		self.ptr=file(self.path,"rb+")
 
 #		print "rewrite ",self.linelen
 


### PR DESCRIPTION
Additional fixes to ones introduced in a597da095fdbce96cab5cb47f18c1efad99dc3ed to fix the LST problem on Windows.

Traceback from xref.
```
e2proc2d.py sets/new_test__ctf_flip.lst r2d_15/input_fp.hdf --fp=0 --verbose=0 --inplace
Traceback (most recent call last):
  File "C:\EMAN2\Library\bin\e2proc2d.py", line 1158, in <module>
    main()
  File "C:\EMAN2\Library\bin\e2proc2d.py", line 583, in main
    d.read_image(infile, i)
  File "C:\EMAN2\lib\site-packages\EMAN2db.py", line 439, in db_read_image
    return self.read_image_c(fsp,*parms, **kparms)
RuntimeError: FileAccessException at ..\..\work\libEM\lstfastio.cpp:186: error with 'P╛╧─· ': 'cannot access file 'P╛╧─· '' caught
```
xref: https://groups.google.com/forum/#!topic/eman2/yL34kvOAjU8