### PR TITLE
Use git to get commit hash

### DIFF
--- a/programs/CMakeLists.txt
+++ b/programs/CMakeLists.txt
@@ -44,7 +44,8 @@ IF(WIN32)
 		)
 ENDIF(WIN32)
 
-execute_process(COMMAND git describe --always --dirty
+find_program(GIT_EXECUTABLE git)
+execute_process(COMMAND ${GIT_EXECUTABLE} describe --always --dirty
 				WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 				OUTPUT_VARIABLE EMAN_GITHASH
 				OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/programs/CMakeLists.txt
+++ b/programs/CMakeLists.txt
@@ -45,15 +45,17 @@ IF(WIN32)
 ENDIF(WIN32)
 
 find_program(GIT_EXECUTABLE git)
-execute_process(COMMAND ${GIT_EXECUTABLE} describe --always --dirty
-				WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-				OUTPUT_VARIABLE EMAN_GITHASH
-				OUTPUT_STRIP_TRAILING_WHITESPACE
-				)
-string(REGEX REPLACE
-	   "^.*-.*-g" ""   # git-describe output: <tag>-<num-of-commits-since-tag>-g<hash>
-	   EMAN_GITHASH ${EMAN_GITHASH}
-	   )
+if(GIT_EXECUTABLE)
+	execute_process(COMMAND ${GIT_EXECUTABLE} describe --always --dirty
+					WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+					OUTPUT_VARIABLE EMAN_GITHASH
+					OUTPUT_STRIP_TRAILING_WHITESPACE
+					)
+	string(REGEX REPLACE
+		   "^.*-.*-g" ""   # git-describe output: <tag>-<num-of-commits-since-tag>-g<hash>
+		   EMAN_GITHASH ${EMAN_GITHASH}
+		   )
+endif()
 
 string(TIMESTAMP EMAN_TIMESTAMP "%Y-%m-%d %H:%M")
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/e2version.py.in

--- a/programs/CMakeLists.txt
+++ b/programs/CMakeLists.txt
@@ -44,8 +44,13 @@ IF(WIN32)
 		)
 ENDIF(WIN32)
 
+execute_process(COMMAND git describe --always --dirty
+				WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+				OUTPUT_VARIABLE EMAN_GITHASH
+				OUTPUT_STRIP_TRAILING_WHITESPACE
+				)
+
 string(TIMESTAMP EMAN_TIMESTAMP "%Y-%m-%d %H:%M")
-string(SUBSTRING "$ENV{GIT_FULL_HASH}" 0 7 EMAN_GITHASH)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/e2version.py.in
 				${CMAKE_INSTALL_PREFIX}/bin/e2version.py
 				)

--- a/programs/CMakeLists.txt
+++ b/programs/CMakeLists.txt
@@ -50,6 +50,10 @@ execute_process(COMMAND ${GIT_EXECUTABLE} describe --always --dirty
 				OUTPUT_VARIABLE EMAN_GITHASH
 				OUTPUT_STRIP_TRAILING_WHITESPACE
 				)
+string(REGEX REPLACE
+	   "^.*-.*-g" ""
+	   EMAN_GITHASH ${EMAN_GITHASH}
+	   )
 
 string(TIMESTAMP EMAN_TIMESTAMP "%Y-%m-%d %H:%M")
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/e2version.py.in

--- a/programs/CMakeLists.txt
+++ b/programs/CMakeLists.txt
@@ -51,7 +51,7 @@ execute_process(COMMAND ${GIT_EXECUTABLE} describe --always --dirty
 				OUTPUT_STRIP_TRAILING_WHITESPACE
 				)
 string(REGEX REPLACE
-	   "^.*-.*-g" ""
+	   "^.*-.*-g" ""   # git-describe output: <tag>-<num-of-commits-since-tag>-g<hash>
 	   EMAN_GITHASH ${EMAN_GITHASH}
 	   )
 

--- a/programs/CMakeLists.txt
+++ b/programs/CMakeLists.txt
@@ -51,8 +51,9 @@ if(GIT_EXECUTABLE)
 					OUTPUT_VARIABLE EMAN_GITHASH
 					OUTPUT_STRIP_TRAILING_WHITESPACE
 					)
+	# git-describe output: <tag>-<num-of-commits-since-tag>-g<hash>
 	string(REGEX REPLACE
-		   "^.*-.*-g" ""   # git-describe output: <tag>-<num-of-commits-since-tag>-g<hash>
+		   "^.*-.*-g" ""
 		   EMAN_GITHASH ${EMAN_GITHASH}
 		   )
 endif()


### PR DESCRIPTION
Using git to get the commit hash works for local dev builds as opposed to only conda-build builds. Every time cmake is run the hash will be updated with the current commit hash. If there are uncommitted changes `-dirty` (git's default) is appended to the commit hash.

---

**Sample Output**
When working directory is clean:
```
$ e2version.py
EMAN 2.2 (GITHUB: 2017-08-03 16:16 - commit: d478266)
Your EMAN2 is running on: Mac OS 10.11.6 x86_64
Your Python version is: 2.7.13
```

When there are uncommitted changes:
```
$ e2version.py
EMAN 2.2 (GITHUB: 2017-08-03 16:18 - commit: 6845205-dirty)
Your EMAN2 is running on: Mac OS 10.11.6 x86_64
Your Python version is: 2.7.13
```
