### PR TITLE
Remove legacy test from CircleCI to free unused container [ci skip]

### DIFF
--- a/ci_support/build_no_envars.sh
+++ b/ci_support/build_no_envars.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-echo "This test has been removed. It is kept here as a placeholder for CircleCI."

--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,5 @@ test:
     - bash:
         parallel: true
         files:
-            - ci_support/build_no_envars.sh
             - ci_support/build_with_envars.sh
             - ci_support/build_recipe.sh


### PR DESCRIPTION
We have 4 containers available on CircleCI. Reducing the tests to 2 will allow to run 2 commits simultaneously. 🎉 