### PR TITLE
Update tests after removing cmake from eman-deps, remove cmake from recipe

### DIFF
--- a/ci_support/setup_conda.sh
+++ b/ci_support/setup_conda.sh
@@ -11,3 +11,5 @@ bash $MINICONDA_FILE -b
 # Configure conda
 source ${HOME}/miniconda2/bin/activate root
 conda config --set show_channel_urls true
+
+conda install cmake=3.8 -c conda-forge --yes --quiet

--- a/recipes/eman/meta.yaml
+++ b/recipes/eman/meta.yaml
@@ -7,8 +7,6 @@ source:
 
 requirements:
     {% set reqs_common = [
-            "cmake 3.8.*",    # [not linux]
-            "cmake 3.7.*",    # [linux]
             "szip",        # [win]
             "msinttypes",  # [win]
             "python 2.7.*",


### PR DESCRIPTION
The trick (to fix cmake problems we have when cmake is installed as a build requirement) is to install cmake before eman dependencies, so conda installs cmake dependencies consistently. So, cmake is removed from eman-deps and the recipe and installed before the build step in the recipe test and before installing eman dependencies in the non-recipe test.