### PR TITLE
Add CMake custom targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,6 +275,11 @@ ADD_SUBDIRECTORY(doc)
 ADD_SUBDIRECTORY(images)
 ADD_SUBDIRECTORY(recipes)
 
+add_custom_target(PythonFiles
+				  COMMAND ${CMAKE_COMMAND} -DCOMPONENT=PythonFiles -P cmake_install.cmake
+				  DEPENDS Programs EMPyLibs QtGuiFiles
+				  )
+
 if(NOT WIN32)
 	install(CODE "execute_process(
 					COMMAND ${CMAKE_COMMAND} -E create_symlink ${EMAN_PREFIX}/bin/sxgui.py ${EMAN_PREFIX}/bin/sphire

--- a/libpyEM/CMakeLists.txt
+++ b/libpyEM/CMakeLists.txt
@@ -80,8 +80,15 @@ if(ENABLE_OPENGL)
 	target_link_libraries(pyMarchingCubes2 OpenGL::OpenGL)
 endif()
 
+add_custom_target(EMPyLibs
+				  COMMAND ${CMAKE_COMMAND} -DCOMPONENT=EMPyLibs -P cmake_install.cmake
+				  )
+
 file(GLOB empythonlibs "${CMAKE_CURRENT_SOURCE_DIR}/*.py")
-install(FILES ${empythonlibs} DESTINATION ${SP_DIR})
+install(FILES ${empythonlibs}
+		DESTINATION ${SP_DIR}
+		COMPONENT EMPyLibs
+		)
 
 add_subdirectory(qtgui)
 

--- a/libpyEM/qtgui/CMakeLists.txt
+++ b/libpyEM/qtgui/CMakeLists.txt
@@ -1,3 +1,7 @@
+add_custom_target(QtGuiFiles
+				  COMMAND ${CMAKE_COMMAND} -DCOMPONENT=QtGuiFiles -P cmake_install.cmake
+				  )
+
 FILE(GLOB qtguifiles "${CMAKE_CURRENT_SOURCE_DIR}/*.py")
 FILE(GLOB exclusionlist "em3Dhelloworld.py")
 
@@ -7,4 +11,7 @@ LIST(REMOVE_ITEM qtguifiles ${exclusionlist})
 
 # MESSAGE("reduced gui files: ${qtguifiles}")
 
-INSTALL(FILES ${qtguifiles} DESTINATION  ${SP_DIR})
+INSTALL(FILES ${qtguifiles}
+		DESTINATION  ${SP_DIR}
+		COMPONENT QtGuiFiles
+		)

--- a/programs/CMakeLists.txt
+++ b/programs/CMakeLists.txt
@@ -27,9 +27,15 @@ FILE(GLOB exclusion_list
 			e2remoted.py
 			e2tomosim.py
 		)
+
+add_custom_target(Programs
+				  COMMAND ${CMAKE_COMMAND} -DCOMPONENT=Programs -P cmake_install.cmake
+				  )
+
 LIST(REMOVE_ITEM e2programs ${exclusion_list})
 INSTALL(PROGRAMS ${e2programs}
-  DESTINATION    bin
+		DESTINATION    bin 
+		COMPONENT Programs
 )
 
 IF(WIN32)


### PR DESCRIPTION
In CMake it is possible to specify installation components which can be installed individually during installation step. This PR adds some custom targets which are used as installation components: `Programs`, `EMPyLibs`, `QtGuiFiles` and `PythonFiles`. All targets install Python files. These targets can be used when only Python files have been edited and there is no need to recompile any C++ code. These targets, except `PythonFiles`, have no dependencies set, so they will install only their own files. This may save significant time compared to `make install`. `PythonFiles` is a target that doesn't install any files, but depends on the others. So, it can be used to install all three targets in one shot instead of specifying all three one by one. 

**Usage**
`make Programs`
`make EMPyLibs`
`make QtGuiFiles`
`make PythonFiles` equivalent to `make Programs EMPyLibs QtGuiFiles`