### PR TITLE
[NO MERGE] Tests speedup due to new flags introduced in fftw-mpi

### DIFF
--- a/ci_support/build_no_recipe.sh
+++ b/ci_support/build_no_recipe.sh
@@ -5,9 +5,9 @@ source ci_support/setup_conda.sh
 # Following Wiki instructions at
 # http://blake.bcm.edu/emanwiki/EMAN2/COMPILE_EMAN2_ANACONDA
 if [ "$(uname -s)" != "Darwin" ];then
-    conda install --yes --quiet eman-deps="*"="np18*" -c cryoem -c defaults -c conda-forge
+    conda install --yes --quiet eman-deps="*"="np18*" -c cryoem/label/dev -c cryoem -c defaults -c conda-forge
 else
-    conda install --yes --quiet eman-deps -c cryoem -c defaults -c conda-forge
+    conda install --yes --quiet eman-deps -c cryoem/label/dev -c cryoem -c defaults -c conda-forge
 fi
 
 # Build and install eman2

--- a/ci_support/build_recipe.sh
+++ b/ci_support/build_recipe.sh
@@ -7,7 +7,7 @@ export CPU_COUNT=2
 conda install conda-build=2 -c defaults --yes --quiet
 
 if [ "$(uname -s)" != "Darwin" ];then
-    conda build recipes/eman -c cryoem -c defaults -c conda-forge --numpy 1.8
+    conda build recipes/eman -c cryoem/label/dev -c cryoem -c defaults -c conda-forge --numpy 1.8
 else
-    conda build recipes/eman -c cryoem -c defaults -c conda-forge
+    conda build recipes/eman -c cryoem/label/dev -c cryoem -c defaults -c conda-forge
 fi


### PR DESCRIPTION
Copied some flags introduced to fftw on conda-forge, https://github.com/conda-forge/fftw-feedstock/commit/1918f4bd9c0d2795ad5973243ef9f99b91eb740f. e2speedtest results before and after.

| | recipe (before) | non-recipe (before) | recipe (after) | non-recipe (after) |
|-|-------|------------|--------|------------|
|OSX | [0.5511](https://travis-ci.org/cryoem/eman2/jobs/267325271#L4072) | [0.7173](https://travis-ci.org/cryoem/eman2/jobs/267325272#L3074) | [0.6102](https://travis-ci.org/cryoem/eman2/jobs/267332877#L4073) | [0.6680](https://travis-ci.org/cryoem/eman2/jobs/267332879#L3073) |
|Linux |  0.7568 | 0.7573 | 0.8176 | 0.8120  |