### PR TITLE
Change pydusa recipe

### DIFF
--- a/recipes/pydusa/meta.yaml
+++ b/recipes/pydusa/meta.yaml
@@ -3,8 +3,8 @@ package:
     version: 1.15
 
 source:
-    url: https://github.com/cryoem/pydusa/archive/master.tar.gz
-    fn: pydusa-master.tar.gz
+    url: https://github.com/cryoem/pydusa/archive/{{environ.get('GIT_PYDUSA_VERSION', 'v20170831')}}.tar.gz
+    fn: pydusa-{{environ.get('GIT_PYDUSA_VERSION', 'v20170831')}}.tar.gz
 
 build:
     number: 0

--- a/utils/build_pydusa_numpy.sh
+++ b/utils/build_pydusa_numpy.sh
@@ -2,8 +2,6 @@
 
 # Builds numpy version(s), if not specified build all versions, 1.5 - 1.12
 
-source activate root
-
 # unset args before using, it is set in activate script above
 unset args
 for elem in ${@};do

--- a/utils/build_pydusa_numpy.sh
+++ b/utils/build_pydusa_numpy.sh
@@ -2,6 +2,8 @@
 
 # Builds numpy version(s), if not specified build all versions, 1.5 - 1.12
 
+source activate root
+
 # unset args before using, it is set in activate script above
 unset args
 for elem in ${@};do
@@ -17,11 +19,16 @@ set -xe
 
 RECIPES_DIR=$(cd $(dirname $0)/../recipes && pwd -P)
 
-if [ ${#args} -lt 1 ];then
+number_of_words=$(wc -w <<< "${args[@]}")
+if [ ${number_of_words} -le 0 ];then
     numpy_versions=( 1.5 1.6 1.7 1.8 1.9 1.10 1.11 1.12 )
+elif [ ${number_of_words} -le 1 ];then
+    numpy_versions=${args[0]}
 else
-    numpy_versions=${args[@]}
+    numpy_versions=${args[0]}
+    export GIT_PYDUSA_VERSION=${args[1]}
 fi
+
 
 for v in ${numpy_versions[@]};do
     conda build "${RECIPES_DIR}/pydusa" --numpy ${v} ${opts[@]}


### PR DESCRIPTION
We figured out, that the pydusa recipe is always using the latest master branch and this resulted in a broken installer a couple of days ago.

I added version tags to the pydusa repository and changed the recipe/installation script, so that users will use the default version (in this case tag v20170831), but developers do still have the freedom to build other tags/branches by adding a second argument next to the numpy version.

@shadowwalkersb Do you agree with the changes or do you have another way of doing it?
I am not really familiar with anaconda recipes yet.