### PR TITLE
Fix pydusa build recipe

### DIFF
--- a/utils/build_pydusa_numpy.sh
+++ b/utils/build_pydusa_numpy.sh
@@ -23,7 +23,7 @@ RECIPES_DIR=$(cd $(dirname $0)/../recipes && pwd -P)
 case ${#args[@]} in
     1|2) numpy_versions=${args[0]}
         
-        export GIT_PYDUSA_BRANCH=${2:-"v20170831"}
+        export GIT_PYDUSA_BRANCH=${args[1]:-"v20170831"}
         ;;
 
     *) print_usage


### PR DESCRIPTION
- Do not use second command line argument for the branch, but second args value