### PR TITLE
Added option flags to openmpi uninstall

### DIFF
--- a/utils/uninstall_openmpi.sh
+++ b/utils/uninstall_openmpi.sh
@@ -2,13 +2,4 @@
 
 set -x
 
-for elem in ${@};do
-    regex=-*
-    if [[ $elem == $regex ]];then
-        opts=( ${opts[@]} $elem )
-    else
-        args=( ${args[@]} $elem )
-    fi
-done
-
-conda remove openmpi --force ${opts[@]}
+conda remove openmpi --force ${@}

--- a/utils/uninstall_openmpi.sh
+++ b/utils/uninstall_openmpi.sh
@@ -2,4 +2,13 @@
 
 set -x
 
-conda remove openmpi --force
+for elem in ${@};do
+    regex=-*
+    if [[ $elem == $regex ]];then
+        opts=( ${opts[@]} $elem )
+    else
+        args=( ${args[@]} $elem )
+    fi
+done
+
+conda remove openmpi --force ${opts[@]}


### PR DESCRIPTION
I would like to add the option flag to the conda remove command.

The command I would like to use is  
  conda remove openmpi --force -y
so the command does not require user input, when automating the installation.
But I would like to keep this optional, so that users will not uninstall openmpi by accident.