### PR TITLE
GUI test framework setup

### DIFF
--- a/libpyEM/EMAN2.py
+++ b/libpyEM/EMAN2.py
@@ -519,9 +519,9 @@ class EMArgumentParser(argparse.ArgumentParser):
 			self.add_argument('--version', action='version', version=version)
 		self.add_argument("postionalargs", nargs="*")
 
-	def parse_args(self):
+	def parse_args(self, args=None):
 		""" Masquerade as optpaser parse options """
-		parsedargs = argparse.ArgumentParser.parse_args(self)
+		parsedargs = argparse.ArgumentParser.parse_args(self, args)
 		return (parsedargs, parsedargs.postionalargs)
 
 	def add_pos_argument(self, **kwargs):

--- a/libpyEM/qtgui/emapplication.py
+++ b/libpyEM/qtgui/emapplication.py
@@ -38,6 +38,7 @@ import sys
 from emimageutil import EMParentWin
 from EMAN2 import remove_directories_from_name, get_image_directory,get_3d_font_renderer, E2end,get_platform
 import EMAN2db
+import EMAN2
 import weakref
 from libpyGLUtils2 import *
 
@@ -302,10 +303,11 @@ class EMApp(QtGui.QApplication):
 		#print "couldn't close",child
 		
 	def execute(self, logid=None):
-		self.exec_()
 		print(logid)
 		if logid: E2end(logid) # We need to log the end of the process, don't we....
-		return sys.exit()
+		if not hasattr(EMAN2, '_called_from_test'):
+			self.exec_()
+			return sys.exit()
 		
 	def hide_specific(self,child,inspector_too=True):
 		for child_ in self.children:

--- a/programs/e2RCTboxer.py
+++ b/programs/e2RCTboxer.py
@@ -109,6 +109,8 @@ Usage: e2RCTboxer.py untilted.hdf tilted.hdf options.
 		rctboxer.init_control_pannel()
 		rctboxer.init_control_pannel_tools()			# Initialize control panel tools, this needs to be done last as loaded data maybe be used
 		application.execute()
+		
+		return rctboxer
 	
 	# Clean up
 	E2end(logid)

--- a/programs/e2RCTboxer.py
+++ b/programs/e2RCTboxer.py
@@ -46,7 +46,7 @@ import os, sys, itertools
 
 EMBOXERRCT_DB = "e2boxercache/rctboxer.json"
 
-def main():
+def main(sys_argv=None):
 	progname = os.path.basename(sys.argv[0])
 	usage = """prog [options] <untilted micrograph> <tilted micrograph>....
 This is a tilted - untilted particle particle picker, for use in RCT particle picking. A tilted and untilted micrograph are loaded and the user picks a untilted particle and a corresponding tilted particle.
@@ -77,7 +77,7 @@ Usage: e2RCTboxer.py untilted.hdf tilted.hdf options.
 
 
 	# Options need to be accessible, anywhere
-	(options, args) = parser.parse_args()
+	(options, args) = parser.parse_args(sys_argv)
 	
 	logid=E2init(sys.argv,options.ppid)
 	

--- a/programs/e2RCTboxer.py
+++ b/programs/e2RCTboxer.py
@@ -46,6 +46,8 @@ import os, sys, itertools
 
 EMBOXERRCT_DB = "e2boxercache/rctboxer.json"
 
+application = EMApp()
+
 def main(sys_argv=None):
 	progname = os.path.basename(sys.argv[0])
 	usage = """prog [options] <untilted micrograph> <tilted micrograph>....
@@ -102,7 +104,6 @@ Usage: e2RCTboxer.py untilted.hdf tilted.hdf options.
 		if options.write_boxes: rctproc.write_boxes()
 	else:
 		# Open Application, setup rct object, and run
-		application = EMApp()
 		rctboxer = RCTboxer(application, options.boxsize)	# Initialize the boxertools
 		rctboxer.load_untilt_image(args[0])		# Load the untilted image
 		rctboxer.load_tilt_image(args[1])		# Load the tilted image

--- a/programs/e2boxer.py
+++ b/programs/e2boxer.py
@@ -88,7 +88,7 @@ def load_micrograph(filename):
 	img["apix_z"]=apix
 	return img
 
-def main():
+def main(sys_argv=None):
 	progname = os.path.basename(sys.argv[0])
 	usage = """prog [options] <image> <image2>....
 
@@ -121,7 +121,7 @@ def main():
 	parser.add_argument("--ppid", type=int, help="Set the PID of the parent process, used for cross platform PPID",default=-1)
 	parser.add_argument("--verbose", "-v", dest="verbose", action="store", metavar="n", type=int, default=0, help="verbose level [0-9], higner number means higher level of verboseness")
 
-	(options, args) = parser.parse_args()
+	(options, args) = parser.parse_args(sys_argv)
 	
 	global invert_on_read
 	if options.invert : invert_on_read = True

--- a/programs/e2boxer.py
+++ b/programs/e2boxer.py
@@ -280,7 +280,9 @@ def main(sys_argv=None):
 		app=EMApp()
 		gui=GUIBoxer(args,options.voltage,options.apix,options.cs,options.ac,options.boxsize,options.ptclsize,options.threads)
 		gui.show()
-		app.exec_()
+		app.execute()
+		
+		return gui
 
 	if options.write_dbbox:
 		write_boxfiles(args,boxsize)

--- a/programs/e2boxer.py
+++ b/programs/e2boxer.py
@@ -39,9 +39,6 @@ import threading
 import Queue
 import os,sys
 
-from emapplication import EMApp
-app=EMApp()
-
 apix=0
 
 class nothing:
@@ -56,6 +53,9 @@ try:
 	from emimagemx import EMImageMXWidget
 	from valslider import ValSlider,CheckBox,ValBox
 	from emshape import EMShape
+	
+	from emapplication import EMApp
+	app=EMApp()
 except:
 	QtGui=nothing()
 	QtCore=nothing()

--- a/programs/e2boxer.py
+++ b/programs/e2boxer.py
@@ -39,6 +39,9 @@ import threading
 import Queue
 import os,sys
 
+from emapplication import EMApp
+app=EMApp()
+
 apix=0
 
 class nothing:
@@ -276,8 +279,6 @@ def main(sys_argv=None):
 			print("=====================================")
 			print("ERROR: GUI mode unavailable without PyQt4")
 			sys.exit(1)
-		from emapplication import EMApp
-		app=EMApp()
 		gui=GUIBoxer(args,options.voltage,options.apix,options.cs,options.ac,options.boxsize,options.ptclsize,options.threads)
 		gui.show()
 		app.execute()

--- a/programs/e2cmpxplor.py
+++ b/programs/e2cmpxplor.py
@@ -68,6 +68,8 @@ read into memory. Do not use it on large sets of particles !!!
 	em_app.show()
 	em_app.execute()
 	
+	return window
+	
 	E2end(logid)
 
 

--- a/programs/e2cmpxplor.py
+++ b/programs/e2cmpxplor.py
@@ -40,7 +40,7 @@ from PyQt4 import QtGui,QtCore
 from emimagemx import EMImageMXModule
 
 	
-def main():
+def main(sys_argv=None):
 	progname = os.path.basename(sys.argv[0])
 	usage = """prog  <projection file>  <particles file>
 	
@@ -51,7 +51,7 @@ read into memory. Do not use it on large sets of particles !!!
 	parser = EMArgumentParser(usage=usage,version=EMANVERSION)
 	parser.add_argument("--ppid", type=int, help="Set the PID of the parent process, used for cross platform PPID",default=-1)
 
-	(options, args) = parser.parse_args()
+	(options, args) = parser.parse_args(sys_argv)
 	
 	if len(args)<2 :
 		print("Error, please specify projection file and particles file")

--- a/programs/e2cmpxplor.py
+++ b/programs/e2cmpxplor.py
@@ -40,6 +40,8 @@ from PyQt4 import QtGui,QtCore
 from emimagemx import EMImageMXModule
 
 	
+em_app = EMApp()
+
 def main(sys_argv=None):
 	progname = os.path.basename(sys.argv[0])
 	usage = """prog  <projection file>  <particles file>
@@ -59,7 +61,6 @@ read into memory. Do not use it on large sets of particles !!!
 	
 	logid=E2init(sys.argv,options.ppid)
 	
-	em_app = EMApp()
 	window = EM3DGLWidget() #TODO: see if this should be a subclass of EMSymViewerWidget instead
 	explorer = EMCmpExplorer(window)
 	window.set_model(explorer)

--- a/programs/e2ctfsim.py
+++ b/programs/e2ctfsim.py
@@ -70,7 +70,9 @@ A simple CTF simulation program.
 	app=EMApp()
 	gui=GUIctfsim(app,options.apix,options.voltage,options.cs,options.ac,options.samples,options.apply)
 	gui.show_guis()
-	app.exec_()
+	app.execute()
+	
+	return gui
 
 #		print "done execution"
 

--- a/programs/e2ctfsim.py
+++ b/programs/e2ctfsim.py
@@ -46,6 +46,8 @@ import weakref
 import traceback
 from numpy import array,arange
 
+from emapplication import EMApp
+app=EMApp()
 
 def main(sys_argv=None):
 	progname = os.path.basename(sys.argv[0])
@@ -66,8 +68,6 @@ A simple CTF simulation program.
 
 	(options, args) = parser.parse_args(sys_argv)
 
-	from emapplication import EMApp
-	app=EMApp()
 	gui=GUIctfsim(app,options.apix,options.voltage,options.cs,options.ac,options.samples,options.apply)
 	gui.show_guis()
 	app.execute()

--- a/programs/e2ctfsim.py
+++ b/programs/e2ctfsim.py
@@ -47,7 +47,7 @@ import traceback
 from numpy import array,arange
 
 
-def main():
+def main(sys_argv=None):
 	progname = os.path.basename(sys.argv[0])
 
 	usage = """prog [options]
@@ -64,7 +64,7 @@ A simple CTF simulation program.
 	parser.add_argument("--apply",type=str,default=None,help="A 2-D image file which the CTF will be applied to in real-time")
 	parser.add_argument("--verbose", "-v", dest="verbose", action="store", metavar="n", type=int, default=0, help="verbose level [0-9], higner number means higher level of verboseness")
 
-	(options, args) = parser.parse_args()
+	(options, args) = parser.parse_args(sys_argv)
 
 	from emapplication import EMApp
 	app=EMApp()

--- a/programs/e2ctfsim.py
+++ b/programs/e2ctfsim.py
@@ -46,9 +46,6 @@ import weakref
 import traceback
 from numpy import array,arange
 
-from emapplication import EMApp
-app=EMApp()
-
 def main(sys_argv=None):
 	progname = os.path.basename(sys.argv[0])
 
@@ -82,6 +79,9 @@ try:
 	from PyQt4.QtCore import Qt
 	from emshape import *
 	from valslider import ValSlider
+	
+	from emapplication import EMApp
+	app=EMApp()
 except:
 	print("Error: PyQt4 must be installed")
 	sys.exit(1)

--- a/programs/e2display.py
+++ b/programs/e2display.py
@@ -45,6 +45,8 @@ from OpenGL import GL, GLU, GLUT
 from PyQt4 import QtCore, QtGui, QtOpenGL
 from PyQt4.QtCore import Qt
 
+app = EMApp()
+
 def main(sys_argv=None):
 	progname = os.path.basename(sys.argv[0])
 	usage = """prog [options] <image file> ...
@@ -73,7 +75,6 @@ def main(sys_argv=None):
 
 #	logid=E2init(sys.argv)
 
-	app = EMApp()
 	#gapp = app
 	#QtGui.QApplication(sys.argv)
 	win=[]

--- a/programs/e2display.py
+++ b/programs/e2display.py
@@ -45,7 +45,7 @@ from OpenGL import GL, GLU, GLUT
 from PyQt4 import QtCore, QtGui, QtOpenGL
 from PyQt4.QtCore import Qt
 
-def main():
+def main(sys_argv=None):
 	progname = os.path.basename(sys.argv[0])
 	usage = """prog [options] <image file> ...
 
@@ -69,7 +69,7 @@ def main():
 	parser.add_argument("--ppid", type=int, help="Set the PID of the parent process, used for cross platform PPID",default=-2)
 	parser.add_argument("--verbose", "-v", dest="verbose", action="store", metavar="n", type=int, default=0, help="verbose level [0-9], higner number means higher level of verboseness")
 
-	(options, args) = parser.parse_args()
+	(options, args) = parser.parse_args(sys_argv)
 
 #	logid=E2init(sys.argv)
 

--- a/programs/e2display.py
+++ b/programs/e2display.py
@@ -130,7 +130,9 @@ def main(sys_argv=None):
 	if options.fullrange:
 		revert_full_range(fullrangeparms)
 
-	app.exec_()
+	app.execute()
+	
+	return dialog
 
 #	E2end(logid)
 

--- a/programs/e2evalimage.py
+++ b/programs/e2evalimage.py
@@ -65,7 +65,7 @@ sfcurve=None		# This will store a global structure factor curve if specified
 sfcurve2=None
 envelopes=[]		# simplex minimizer needs to use a global at the moment
 
-def main():
+def main(sys_argv=None):
 	global debug,logid
 	progname = os.path.basename(sys.argv[0])
 	usage = """prog [options] <single image file> ...
@@ -91,7 +91,7 @@ power spectrum in various ways."""
 	parser.add_argument("--ppid", type=int, help="Set the PID of the parent process, used for cross platform PPID",default=-1)
 	parser.add_argument("--verbose", "-v", dest="verbose", action="store", metavar="n", type=int, default=0, help="verbose level [0-9], higner number means higher level of verboseness")
 
-	(options, args) = parser.parse_args()
+	(options, args) = parser.parse_args(sys_argv)
 
 	logid=E2init(sys.argv,options.ppid)
 

--- a/programs/e2evalimage.py
+++ b/programs/e2evalimage.py
@@ -112,6 +112,8 @@ power spectrum in various ways."""
 	app.execute()
 
 	E2end(logid)
+	
+	return gui
 
 
 

--- a/programs/e2evalimage.py
+++ b/programs/e2evalimage.py
@@ -44,6 +44,9 @@ import threading
 from numpy import array,arange
 import traceback
 
+from emapplication import EMApp
+app=EMApp()
+
 try:
 	from PyQt4 import QtCore, QtGui, QtOpenGL
 	from PyQt4.QtCore import Qt
@@ -95,8 +98,6 @@ power spectrum in various ways."""
 
 	logid=E2init(sys.argv,options.ppid)
 
-	from emapplication import EMApp
-	app=EMApp()
 	gui=GUIEvalImage(args,options.voltage,options.apix,options.cs,options.ac,options.box,options.usefoldername,options.constbfactor,options.astigmatism,options.phaseplate)
 	gui.show()
 

--- a/programs/e2evalparticles.py
+++ b/programs/e2evalparticles.py
@@ -45,6 +45,8 @@ from EMAN2db import *
 from valslider import *
 import traceback
 
+app = EMApp()
+
 def main(sys_argv=None):
 	progname = os.path.basename(sys.argv[0])
 	usage = """prog [classfile]
@@ -66,7 +68,6 @@ def main(sys_argv=None):
 
 	#logid=E2init(sys.argv, options.ppid)
 
-	app = EMApp()
 	control=EMEvalPtclTool(args,verbose=options.verbose)
 	control.show()
 	app.execute()

--- a/programs/e2evalparticles.py
+++ b/programs/e2evalparticles.py
@@ -72,6 +72,8 @@ def main(sys_argv=None):
 	app.execute()
 
 #	E2end(logid)
+	
+	return control
 
 class EMClassPtclTool(QtGui.QWidget):
 	"""This class is a tab widget for inspecting particles within class-averages"""

--- a/programs/e2evalparticles.py
+++ b/programs/e2evalparticles.py
@@ -45,7 +45,7 @@ from EMAN2db import *
 from valslider import *
 import traceback
 
-def main():
+def main(sys_argv=None):
 	progname = os.path.basename(sys.argv[0])
 	usage = """prog [classfile]
 
@@ -62,7 +62,7 @@ def main():
 	parser.add_argument("--ppid", type=int, help="Set the PID of the parent process, used for cross platform PPID",default=-1)
 	parser.add_argument("--verbose", "-v", dest="verbose", action="store", metavar="n", type=int, default=0, help="verbose level [0-9], higner number means higher level of verboseness")
 
-	(options, args) = parser.parse_args()
+	(options, args) = parser.parse_args(sys_argv)
 
 	#logid=E2init(sys.argv, options.ppid)
 

--- a/programs/e2filtertool.py
+++ b/programs/e2filtertool.py
@@ -51,6 +51,8 @@ from emshape import EMShape
 from valslider import *
 import traceback
 
+app = EMApp()
+
 def main(sys_argv=None):
 	progname = os.path.basename(sys.argv[0])
 	usage = """prog [options] <image file>
@@ -76,7 +78,6 @@ def main(sys_argv=None):
 
 #	logid=E2init(sys.argv,options.ppid)
 
-	app = EMApp()
 	pix_init()
 	control=EMFilterTool(datafile=args[0],apix=options.apix,force2d=False,verbose=options.verbose)
 #	control=EMFilterTool(datafile=args[0],apix=options.apix,force2d=options.force2d,verbose=options.verbose)

--- a/programs/e2filtertool.py
+++ b/programs/e2filtertool.py
@@ -51,7 +51,7 @@ from emshape import EMShape
 from valslider import *
 import traceback
 
-def main():
+def main(sys_argv=None):
 	progname = os.path.basename(sys.argv[0])
 	usage = """prog [options] <image file>
 
@@ -66,7 +66,7 @@ def main():
 	parser.add_argument("--ppid", type=int, help="Set the PID of the parent process, used for cross platform PPID",default=-1)
 	parser.add_argument("--verbose", "-v", dest="verbose", action="store", metavar="n", type=int, default=0, help="verbose level [0-9], higner number means higher level of verboseness")
 
-	(options, args) = parser.parse_args()
+	(options, args) = parser.parse_args(sys_argv)
 
 	if len(args) != 1: parser.error("You must specify a single data file on the command-line.")
 	if not file_exists(args[0]): parser.error("%s does not exist" %args[0])

--- a/programs/e2filtertool.py
+++ b/programs/e2filtertool.py
@@ -87,6 +87,8 @@ def main(sys_argv=None):
 	app.execute()
 #	E2end(logid)
 
+	return control
+
 def filtchange(name,value):
 	return {}
 

--- a/programs/e2helixboxer.py
+++ b/programs/e2helixboxer.py
@@ -48,6 +48,8 @@ try:
 
 	ENABLE_GUI = True
 
+	app = EMApp()
+
 except ImportError as e:
 	print("Importing GUI libraries failed!")
 	print(e)
@@ -63,8 +65,6 @@ within a helix. Usually, all particles from a micrograph will have the same dime
 """
 
 E2HELIXBOXER_DB = "bdb:" # used to use "bdb:e2helixboxercache#"
-
-app = EMApp()
 
 def main(sys_argv=None):
 	usage = """e2helixboxer.py --gui <micrograph1> <<micrograph2> <micrograph3> ...

--- a/programs/e2helixboxer.py
+++ b/programs/e2helixboxer.py
@@ -65,7 +65,7 @@ within a helix. Usually, all particles from a micrograph will have the same dime
 E2HELIXBOXER_DB = "bdb:" # used to use "bdb:e2helixboxercache#"
 
 
-def main():
+def main(sys_argv=None):
 	usage = """e2helixboxer.py --gui <micrograph1> <<micrograph2> <micrograph3> ...
 	e2helixboxer.py --gui --helix-width=<width> <micrograph1> <<micrograph2> <micrograph3> ...
 	e2helixboxer.py <options (not --gui)> <micrograph>
@@ -91,7 +91,7 @@ def main():
 	parser.add_argument("--gridding",      action="store_true", default=False, help="Use a gridding method for rotation operations on particles. Requires particles to be square.")
 	parser.add_argument("--save-ext",type=str,default="hdf",dest="save_ext",help="The default file extension to use when saving 'particle' images. This is simply a convenience for improved workflow. If a format other than HDF is used, metadata will be lost when saving.")
 	parser.add_argument("--ppid", type=int, help="Set the PID of the parent process, used for cross platform PPID",default=-1)
-	(options, args) = parser.parse_args()
+	(options, args) = parser.parse_args(sys_argv)
 
 	if len(args)==0 :
 		print("ERROR: please provide a list of files to be boxed at the command line")

--- a/programs/e2helixboxer.py
+++ b/programs/e2helixboxer.py
@@ -64,6 +64,7 @@ within a helix. Usually, all particles from a micrograph will have the same dime
 
 E2HELIXBOXER_DB = "bdb:" # used to use "bdb:e2helixboxercache#"
 
+app = EMApp()
 
 def main(sys_argv=None):
 	usage = """e2helixboxer.py --gui <micrograph1> <<micrograph2> <micrograph3> ...
@@ -122,7 +123,6 @@ def main(sys_argv=None):
 	if options.gui:
 		if ENABLE_GUI:
 			logid=E2init(sys.argv,options.ppid)
-			app = EMApp()
 			helixboxer = EMHelixBoxerWidget(args, app, options.helix_width,options.save_ext)
 			helixboxer.show()
 			app.execute()

--- a/programs/e2helixboxer.py
+++ b/programs/e2helixboxer.py
@@ -127,6 +127,8 @@ def main(sys_argv=None):
 			helixboxer.show()
 			app.execute()
 			E2end(logid)
+			
+			return helixboxer
 		else:
 			return
 	else:

--- a/programs/e2history.py
+++ b/programs/e2history.py
@@ -43,6 +43,9 @@ import EMAN2db
 
 # also defined in EMAN2, but we don't want to have to import it
 
+from emapplication import EMApp
+app = EMApp()
+
 def main(sys_argv=None):
 	progname = os.path.basename(sys.argv[0])
 	usage = progname + """ [options]
@@ -58,8 +61,6 @@ def main(sys_argv=None):
 	(options, args) = parser.parse_args(sys_argv)
 	
 	if options.gui:
-		from emapplication import EMApp
-		app = EMApp()
 		hist = HistoryForm(app,os.getcwd())
 		app.show()
 		app.execute()

--- a/programs/e2history.py
+++ b/programs/e2history.py
@@ -64,6 +64,8 @@ def main(sys_argv=None):
 		app.show()
 		app.execute()
 		
+		return hist
+		
 	else: print_to_std_out(options.all)
 
 class HistoryForm:

--- a/programs/e2history.py
+++ b/programs/e2history.py
@@ -43,7 +43,7 @@ import EMAN2db
 
 # also defined in EMAN2, but we don't want to have to import it
 
-def main():
+def main(sys_argv=None):
 	progname = os.path.basename(sys.argv[0])
 	usage = progname + """ [options]
 	A tool for displaying EMAN2 command history
@@ -55,7 +55,7 @@ def main():
 	parser.add_argument("--ppid", type=int, help="Set the PID of the parent process, used for cross platform PPID",default=-1)
 	parser.add_argument("--verbose", "-v", dest="verbose", action="store", metavar="n", type=int, default=0, help="verbose level [0-9], higner number means higher level of verboseness")
 	
-	(options, args) = parser.parse_args()
+	(options, args) = parser.parse_args(sys_argv)
 	
 	if options.gui:
 		from emapplication import EMApp

--- a/programs/e2projectmanager.py
+++ b/programs/e2projectmanager.py
@@ -2101,7 +2101,9 @@ GUI directly to browse the contents of old-style projects.""")
 	pm.show()
 	try: pm.raise_()
 	except: pass
-	app.exec_()
+	app.execute()
+	
+	return pm
 
 if __name__ == "__main__":
 	main()

--- a/programs/e2projectmanager.py
+++ b/programs/e2projectmanager.py
@@ -2084,7 +2084,7 @@ class ProjectDialog(QtGui.QDialog):
 	def _on_cancel(self):
 		self.done(1)
 
-if __name__ == "__main__":
+def main():
 	import sys
 
 	if os.path.isdir("EMAN2DB") and os.path.isfile("EMAN2DB/project.bdb") :
@@ -2102,3 +2102,6 @@ GUI directly to browse the contents of old-style projects.""")
 	try: pm.raise_()
 	except: pass
 	app.exec_()
+
+if __name__ == "__main__":
+	main()

--- a/programs/e2projectmanager.py
+++ b/programs/e2projectmanager.py
@@ -2084,7 +2084,7 @@ class ProjectDialog(QtGui.QDialog):
 	def _on_cancel(self):
 		self.done(1)
 
-def main():
+def main(sys_argv=None):
 	import sys
 
 	if os.path.isdir("EMAN2DB") and os.path.isfile("EMAN2DB/project.bdb") :

--- a/programs/e2projectmanager.py
+++ b/programs/e2projectmanager.py
@@ -2084,6 +2084,9 @@ class ProjectDialog(QtGui.QDialog):
 	def _on_cancel(self):
 		self.done(1)
 
+from emapplication import EMApp
+app = EMApp()
+
 def main(sys_argv=None):
 	import sys
 
@@ -2094,9 +2097,6 @@ first upgrade the project with e2projectupdate21.py. You can still use the e2dis
 GUI directly to browse the contents of old-style projects.""")
 		sys.exit(1)
 
-	from emapplication import EMApp
-	app = EMApp()
-	#app = QtGui.QApplication(sys.argv)
 	pm = EMProjectManager()
 	pm.show()
 	try: pm.raise_()

--- a/programs/e2spt_boxer.py
+++ b/programs/e2spt_boxer.py
@@ -48,11 +48,13 @@ from emshape import EMShape
 from valslider import ValSlider, ValBox
 
 	
+app = EMApp()
+
 def run(cmd):
 	print(cmd)
 	launch_childprocess(cmd)
 	
-def main():
+def main(sys_argv=None):
 	
 	usage="""
 	
@@ -96,7 +98,7 @@ def main():
 	parser.add_argument("--verbose", "-v", dest="verbose", action="store", metavar="n", type=int, default=0, help="verbose level [0-9], higner number means higher level of verboseness")
 
 
-	(options, args) = parser.parse_args()
+	(options, args) = parser.parse_args(sys_argv)
 	
 	logid=E2init(sys.argv)
 
@@ -120,7 +122,6 @@ def main():
 				print("done")
 
 	else:
-		app = EMApp()
 
 		#img=args[0]
 
@@ -135,6 +136,8 @@ def main():
 
 		boxer.show()
 		app.execute()
+		
+		return boxer
 	
 	E2end(logid)
 

--- a/programs/e2spt_wedge.py
+++ b/programs/e2spt_wedge.py
@@ -37,7 +37,9 @@ from emapplication import EMApp
 import emscene3d
 import emdataitem3d 
 
-def main():
+em_app = EMApp()
+
+def main(sys_argv=None):
 	progname = os.path.basename(sys.argv[0])
 	usage = """prog 3Dstack [options]
 	Visulaizse and compute the mean amplitude and sigma in the missing wedge region. After you are sasified that the missing wedge looks sane, compute missing wedge stats
@@ -55,17 +57,20 @@ def main():
 	parser.add_argument("--nogui", action="store_true", default=False, help="Do not launch the GUI and set the average of the missing wedge statistics on all the volumes.")
 	parser.add_argument("--averagestats", action="store_true", default=False, help="Do not launch the GUI and set the average of the missing wedge statistics on all the volumes.")
 
-	(options, args) = parser.parse_args()
+	(options, args) = parser.parse_args(sys_argv)
 
 	logger = E2init(sys.argv, options.ppid)
 
 	stack=args[0]
 	
 	if not options.nogui:	
-		em_app = EMApp()
 		wedgeviewer = MissingWedgeViewer(stack, options.wedgeangle, wedgei=options.wedgei, wedgef=options.wedgef)
 		wedgeviewer.show()
-		ret=em_app.exec_()
+		wedgeviewer.raise_()
+		ret=em_app.execute()
+		
+		return wedgeviewer
+		
 		sys.exit(ret)
 	else:
 		means=[]


### PR DESCRIPTION
This sets up some GUI programs so their main functions can be called and some command line arguments can be passed, then program's widget is returned. To prevent the main loop from blocking, `EMApp.execute()` is refactored to check if the session is a test session, if so `exec_()` is not called and control is returned to the caller. That way test runner programs can call programs with any desired parameters, just like when run from command line, and get the widget which can be used for tests. Programs refactoring procedure followed here, and to follow later to make any GUI program testable, is as follows.

1. Add argument for command line arguments. `main()` -> `main(sys_argv=None)`. Current calls won't be affected by this change.
1. Pass `sys_argv` to the parser. `parser.parse_args()` -> `parser.parse_args(sys_argv)`
1. Make sure that `EMApp.execute()` is called, not `QApplication.exec_()`.
1. Return program's widget after `EMApp.execute()`.

Test framework, tests, code coverage in follow-up PRs.