### PR TITLE
Install qtgui as a package

### DIFF
--- a/broken/e22.py
+++ b/broken/e22.py
@@ -34,11 +34,11 @@ from __future__ import print_function
 
 import EMAN2
 from EMAN2 import *
-from qtgui.emimage import image_update
+from eman2_gui.emimage import image_update
 from PyQt4 import QtCore, QtGui, QtOpenGL
 from PyQt4.QtCore import Qt
 import threading
-from qtgui.emapplication import EMApp
+from eman2_gui.emapplication import EMApp
 
 from IPython.frontend.terminal.ipapp import launch_new_instance
 ttx=False

--- a/broken/e22.py
+++ b/broken/e22.py
@@ -34,11 +34,11 @@ from __future__ import print_function
 
 import EMAN2
 from EMAN2 import *
-from emimage import image_update
+from qtgui.emimage import image_update
 from PyQt4 import QtCore, QtGui, QtOpenGL
 from PyQt4.QtCore import Qt
 import threading
-from emapplication import EMApp
+from qtgui.emapplication import EMApp
 
 from IPython.frontend.terminal.ipapp import launch_new_instance
 ttx=False

--- a/broken/e2flick.py
+++ b/broken/e2flick.py
@@ -34,8 +34,8 @@ from __future__ import print_function
 
 
 #from EMAN2 import *
-#from emimage import EMImage
-#from emimageutil import EMParentWin
+#from qtgui.emimage import EMImage
+#from qtgui.emimageutil import EMParentWin
 import sys
 import os
 #from optparse import OptionParser
@@ -43,8 +43,8 @@ import os
 #from PyQt4.QtCore import Qt
 #from OpenGL import GL,GLU,GLUT
 
-#from emimagemxrotor import * #emimagemxrotor was deprecated and removed from CVS
-#from emapplication import EMStandAloneApplication #EMStandAloneApplication was deprecated and removed from CVS
+#from qtgui.emimagemxrotor import * #emimagemxrotor was deprecated and removed from CVS
+#from qtgui.emapplication import EMStandAloneApplication #EMStandAloneApplication was deprecated and removed from CVS
 from optparse import OptionParser
 
 def main():

--- a/broken/e2flick.py
+++ b/broken/e2flick.py
@@ -34,8 +34,8 @@ from __future__ import print_function
 
 
 #from EMAN2 import *
-#from qtgui.emimage import EMImage
-#from qtgui.emimageutil import EMParentWin
+#from eman2_gui.emimage import EMImage
+#from eman2_gui.emimageutil import EMParentWin
 import sys
 import os
 #from optparse import OptionParser
@@ -43,8 +43,8 @@ import os
 #from PyQt4.QtCore import Qt
 #from OpenGL import GL,GLU,GLUT
 
-#from qtgui.emimagemxrotor import * #emimagemxrotor was deprecated and removed from CVS
-#from qtgui.emapplication import EMStandAloneApplication #EMStandAloneApplication was deprecated and removed from CVS
+#from eman2_gui.emimagemxrotor import * #emimagemxrotor was deprecated and removed from CVS
+#from eman2_gui.emapplication import EMStandAloneApplication #EMStandAloneApplication was deprecated and removed from CVS
 from optparse import OptionParser
 
 def main():

--- a/broken/e2markbadparticles.py
+++ b/broken/e2markbadparticles.py
@@ -42,7 +42,7 @@ from PyQt4.QtCore import Qt
 from qtgui.emapplication import EMApp
 import os
 from EMAN2db import *
-from valslider import *
+from qtgui.valslider import *
 import traceback
 
 def main():

--- a/broken/e2markbadparticles.py
+++ b/broken/e2markbadparticles.py
@@ -33,13 +33,13 @@ from __future__ import print_function
 
 #
 from EMAN2 import *
-from emimagemx import EMImageMXWidget
+from qtgui.emimagemx import EMImageMXWidget
 
 import sys
 from PyQt4 import QtCore, QtGui, QtOpenGL
 from PyQt4.QtCore import Qt
 #from OpenGL import GL,GLU,GLUT
-from emapplication import EMApp
+from qtgui.emapplication import EMApp
 import os
 from EMAN2db import *
 from valslider import *

--- a/broken/e2markbadparticles.py
+++ b/broken/e2markbadparticles.py
@@ -33,16 +33,16 @@ from __future__ import print_function
 
 #
 from EMAN2 import *
-from qtgui.emimagemx import EMImageMXWidget
+from eman2_gui.emimagemx import EMImageMXWidget
 
 import sys
 from PyQt4 import QtCore, QtGui, QtOpenGL
 from PyQt4.QtCore import Qt
 #from OpenGL import GL,GLU,GLUT
-from qtgui.emapplication import EMApp
+from eman2_gui.emapplication import EMApp
 import os
 from EMAN2db import *
-from qtgui.valslider import *
+from eman2_gui.valslider import *
 import traceback
 
 def main():

--- a/broken/e2plotFSC.py
+++ b/broken/e2plotFSC.py
@@ -33,9 +33,9 @@ from __future__ import print_function
 
 from EMAN2 import *
 from EMAN2fsc import *
-from qtgui.emplot2d import EMPlot2DWidget,colortypes
-from qtgui.empmwidgets import PMFSCTableWidget
-from qtgui.emapplication import EMApp
+from eman2_gui.emplot2d import EMPlot2DWidget,colortypes
+from eman2_gui.empmwidgets import PMFSCTableWidget
+from eman2_gui.emapplication import EMApp
 
 def main():
 	progname = os.path.basename(sys.argv[0])

--- a/broken/e2plotFSC.py
+++ b/broken/e2plotFSC.py
@@ -33,9 +33,9 @@ from __future__ import print_function
 
 from EMAN2 import *
 from EMAN2fsc import *
-from emplot2d import EMPlot2DWidget,colortypes
-from empmwidgets import PMFSCTableWidget
-from emapplication import EMApp
+from qtgui.emplot2d import EMPlot2DWidget,colortypes
+from qtgui.empmwidgets import PMFSCTableWidget
+from qtgui.emapplication import EMApp
 
 def main():
 	progname = os.path.basename(sys.argv[0])

--- a/broken/e2preferences.py
+++ b/broken/e2preferences.py
@@ -32,10 +32,10 @@ from __future__ import print_function
 #
 #
 import EMAN2db
-from emdatastorage import ParamDef 
+from qtgui.emdatastorage import ParamDef 
 
-from emsprworkflow import WorkFlowTask
-from emapplication import get_application
+from qtgui.emsprworkflow import WorkFlowTask
+from qtgui.emapplication import get_application
 
 global HOMEDB
 HOMEDB=EMAN2db.EMAN2DB.open_db()
@@ -87,7 +87,7 @@ class EMPreferencesTask(WorkFlowTask):
 		self.emit(QtCore.SIGNAL("task_idle"))
 	
 	def run_form(self):
-		from emform import EMTableFormWidget
+		from qtgui.emform import EMTableFormWidget
 		self.form = EMTableFormWidget(self.get_params())
 		self.form.resize(*self.preferred_size)
 		self.form.setWindowTitle(self.window_title)
@@ -114,7 +114,7 @@ class EMPreferencesTask(WorkFlowTask):
 			
 		
 def main():
-	from emapplication import EMApp
+	from qtgui.emapplication import EMApp
 
 	em_app = EMApp()
 	

--- a/broken/e2preferences.py
+++ b/broken/e2preferences.py
@@ -32,10 +32,10 @@ from __future__ import print_function
 #
 #
 import EMAN2db
-from qtgui.emdatastorage import ParamDef 
+from eman2_gui.emdatastorage import ParamDef 
 
-from qtgui.emsprworkflow import WorkFlowTask
-from qtgui.emapplication import get_application
+from eman2_gui.emsprworkflow import WorkFlowTask
+from eman2_gui.emapplication import get_application
 
 global HOMEDB
 HOMEDB=EMAN2db.EMAN2DB.open_db()
@@ -87,7 +87,7 @@ class EMPreferencesTask(WorkFlowTask):
 		self.emit(QtCore.SIGNAL("task_idle"))
 	
 	def run_form(self):
-		from qtgui.emform import EMTableFormWidget
+		from eman2_gui.emform import EMTableFormWidget
 		self.form = EMTableFormWidget(self.get_params())
 		self.form.resize(*self.preferred_size)
 		self.form.setWindowTitle(self.window_title)
@@ -114,7 +114,7 @@ class EMPreferencesTask(WorkFlowTask):
 			
 		
 def main():
-	from qtgui.emapplication import EMApp
+	from eman2_gui.emapplication import EMApp
 
 	em_app = EMApp()
 	

--- a/broken/em3Dhelloworld.py
+++ b/broken/em3Dhelloworld.py
@@ -42,7 +42,7 @@ from valslider import ValSlider
 from math import *
 from EMAN2 import *
 from time import *
-from emglobjects import EM3DModel, Camera2,get_default_gl_colors,EMViewportDepthTools2
+from qtgui.emglobjects import EM3DModel, Camera2,get_default_gl_colors,EMViewportDepthTools2
 
 MAG_INCREMENT_FACTOR = 1.1
 
@@ -518,8 +518,8 @@ class EMHelloWorldInspector(QtGui.QWidget):
 		
 # This is just for testing, of course
 if __name__ == '__main__':
-	from emapplication import EMApp
-	from emimage3d import EMImage3DWidget
+	from qtgui.emapplication import EMApp
+	from qtgui.emimage3d import EMImage3DWidget
 	em_app = EMApp()
 	window = EMImage3DWidget()
 	hello_world = EM3DHelloWorld(window)

--- a/broken/em3Dhelloworld.py
+++ b/broken/em3Dhelloworld.py
@@ -38,11 +38,11 @@ from PyQt4.QtCore import Qt
 from OpenGL import GL,GLU,GLUT
 from OpenGL.GL import *
 from OpenGL.GLU import *
-from qtgui.valslider import ValSlider
+from eman2_gui.valslider import ValSlider
 from math import *
 from EMAN2 import *
 from time import *
-from qtgui.emglobjects import EM3DModel, Camera2,get_default_gl_colors,EMViewportDepthTools2
+from eman2_gui.emglobjects import EM3DModel, Camera2,get_default_gl_colors,EMViewportDepthTools2
 
 MAG_INCREMENT_FACTOR = 1.1
 
@@ -518,8 +518,8 @@ class EMHelloWorldInspector(QtGui.QWidget):
 		
 # This is just for testing, of course
 if __name__ == '__main__':
-	from qtgui.emapplication import EMApp
-	from qtgui.emimage3d import EMImage3DWidget
+	from eman2_gui.emapplication import EMApp
+	from eman2_gui.emimage3d import EMImage3DWidget
 	em_app = EMApp()
 	window = EMImage3DWidget()
 	hello_world = EM3DHelloWorld(window)

--- a/broken/em3Dhelloworld.py
+++ b/broken/em3Dhelloworld.py
@@ -38,7 +38,7 @@ from PyQt4.QtCore import Qt
 from OpenGL import GL,GLU,GLUT
 from OpenGL.GL import *
 from OpenGL.GLU import *
-from valslider import ValSlider
+from qtgui.valslider import ValSlider
 from math import *
 from EMAN2 import *
 from time import *

--- a/examples/alignbystars.py
+++ b/examples/alignbystars.py
@@ -32,7 +32,7 @@ from __future__ import print_function
 #
 
 from EMAN2 import *
-from emimage import *
+from qtgui.emimage import *
 import time
 import sys
 from optparse import OptionParser

--- a/examples/alignbystars.py
+++ b/examples/alignbystars.py
@@ -32,7 +32,7 @@ from __future__ import print_function
 #
 
 from EMAN2 import *
-from qtgui.emimage import *
+from eman2_gui.emimage import *
 import time
 import sys
 from optparse import OptionParser

--- a/examples/breakbrick.py
+++ b/examples/breakbrick.py
@@ -3,9 +3,9 @@ from __future__ import print_function
 # Muyuan Chen 2016-09
 from EMAN2 import *
 import numpy as np
-from qtgui.emapplication import EMApp
-from qtgui.emimage2d import EMImage2DWidget
-from qtgui.emshape import EMShape
+from eman2_gui.emapplication import EMApp
+from eman2_gui.emimage2d import EMImage2DWidget
+from eman2_gui.emshape import EMShape
 
 import PyQt4
 from PyQt4 import QtCore, QtGui, QtOpenGL

--- a/examples/breakbrick.py
+++ b/examples/breakbrick.py
@@ -3,9 +3,9 @@ from __future__ import print_function
 # Muyuan Chen 2016-09
 from EMAN2 import *
 import numpy as np
-from emapplication import EMApp
-from emimage2d import EMImage2DWidget
-from emshape import EMShape
+from qtgui.emapplication import EMApp
+from qtgui.emimage2d import EMImage2DWidget
+from qtgui.emshape import EMShape
 
 import PyQt4
 from PyQt4 import QtCore, QtGui, QtOpenGL

--- a/examples/displaydemo.py
+++ b/examples/displaydemo.py
@@ -38,9 +38,9 @@ from __future__ import print_function
 from EMAN2 import *
 from math import *
 from PyQt4 import QtCore
-from emapplication import EMApp
-from emimage2d import EMImage2DWidget
-from emshape import EMShape
+from qtgui.emapplication import EMApp
+from qtgui.emimage2d import EMImage2DWidget
+from qtgui.emshape import EMShape
 
 
 def main():

--- a/examples/displaydemo.py
+++ b/examples/displaydemo.py
@@ -38,9 +38,9 @@ from __future__ import print_function
 from EMAN2 import *
 from math import *
 from PyQt4 import QtCore
-from qtgui.emapplication import EMApp
-from qtgui.emimage2d import EMImage2DWidget
-from qtgui.emshape import EMShape
+from eman2_gui.emapplication import EMApp
+from eman2_gui.emimage2d import EMImage2DWidget
+from eman2_gui.emshape import EMShape
 
 
 def main():

--- a/examples/drawshape.py
+++ b/examples/drawshape.py
@@ -6,9 +6,9 @@ import numpy as np
 import weakref
 from PyQt4 import QtCore, QtGui
 from PyQt4.QtCore import Qt
-from emapplication import get_application, EMApp
-from emimage2d import EMImage2DWidget
-from emshape import EMShape
+from qtgui.emapplication import get_application, EMApp
+from qtgui.emimage2d import EMImage2DWidget
+from qtgui.emshape import EMShape
 
 def main():
 	

--- a/examples/drawshape.py
+++ b/examples/drawshape.py
@@ -6,9 +6,9 @@ import numpy as np
 import weakref
 from PyQt4 import QtCore, QtGui
 from PyQt4.QtCore import Qt
-from qtgui.emapplication import get_application, EMApp
-from qtgui.emimage2d import EMImage2DWidget
-from qtgui.emshape import EMShape
+from eman2_gui.emapplication import get_application, EMApp
+from eman2_gui.emimage2d import EMImage2DWidget
+from eman2_gui.emshape import EMShape
 
 def main():
 	

--- a/examples/e2fftsynth.py
+++ b/examples/e2fftsynth.py
@@ -38,7 +38,7 @@ try:
 	from PyQt4 import QtCore, QtGui, QtOpenGL
 	from PyQt4.QtCore import Qt
 	from qtgui.emshape import *
-	from valslider import ValSlider,ValBox
+	from qtgui.valslider import ValSlider,ValBox
 	from qtgui.emimage import EMImageWidget
 	from qtgui.emimage2d import EMImage2DWidget
 	from qtgui.emplot2d import EMPlot2DWidget

--- a/examples/e2fftsynth.py
+++ b/examples/e2fftsynth.py
@@ -37,12 +37,12 @@ from optparse import OptionParser
 try:
 	from PyQt4 import QtCore, QtGui, QtOpenGL
 	from PyQt4.QtCore import Qt
-	from emshape import *
+	from qtgui.emshape import *
 	from valslider import ValSlider,ValBox
-	from emimage import EMImageWidget
-	from emimage2d import EMImage2DWidget
-	from emplot2d import EMPlot2DWidget
-	from emapplication import EMApp
+	from qtgui.emimage import EMImageWidget
+	from qtgui.emimage2d import EMImage2DWidget
+	from qtgui.emplot2d import EMPlot2DWidget
+	from qtgui.emapplication import EMApp
 except:
 	print("Unable to import Python GUI libraries, PYTHONPATH ?")
 	sys.exit(1)

--- a/examples/e2fftsynth.py
+++ b/examples/e2fftsynth.py
@@ -37,12 +37,12 @@ from optparse import OptionParser
 try:
 	from PyQt4 import QtCore, QtGui, QtOpenGL
 	from PyQt4.QtCore import Qt
-	from qtgui.emshape import *
-	from qtgui.valslider import ValSlider,ValBox
-	from qtgui.emimage import EMImageWidget
-	from qtgui.emimage2d import EMImage2DWidget
-	from qtgui.emplot2d import EMPlot2DWidget
-	from qtgui.emapplication import EMApp
+	from eman2_gui.emshape import *
+	from eman2_gui.valslider import ValSlider,ValBox
+	from eman2_gui.emimage import EMImageWidget
+	from eman2_gui.emimage2d import EMImage2DWidget
+	from eman2_gui.emplot2d import EMPlot2DWidget
+	from eman2_gui.emapplication import EMApp
 except:
 	print("Unable to import Python GUI libraries, PYTHONPATH ?")
 	sys.exit(1)

--- a/examples/e2spt_boxer22.py
+++ b/examples/e2spt_boxer22.py
@@ -49,7 +49,7 @@ from qtgui.emimage3d import EMImage3DWidget
 from qtgui.emscene3d import EMScene3D
 from qtgui.emdataitem3d import EMDataItem3D, EMIsosurface
 from qtgui.emshape import EMShape
-from valslider import ValSlider, ValBox
+from qtgui.valslider import ValSlider, ValBox
 
 	
 def run(cmd):

--- a/examples/e2spt_boxer22.py
+++ b/examples/e2spt_boxer22.py
@@ -42,14 +42,14 @@ import numpy as np
 import weakref
 from PyQt4 import QtCore, QtGui
 from PyQt4.QtCore import Qt
-from qtgui.emapplication import get_application, EMApp
-from qtgui.emimage2d import EMImage2DWidget
-from qtgui.emimagemx import EMImageMXWidget
-from qtgui.emimage3d import EMImage3DWidget
-from qtgui.emscene3d import EMScene3D
-from qtgui.emdataitem3d import EMDataItem3D, EMIsosurface
-from qtgui.emshape import EMShape
-from qtgui.valslider import ValSlider, ValBox
+from eman2_gui.emapplication import get_application, EMApp
+from eman2_gui.emimage2d import EMImage2DWidget
+from eman2_gui.emimagemx import EMImageMXWidget
+from eman2_gui.emimage3d import EMImage3DWidget
+from eman2_gui.emscene3d import EMScene3D
+from eman2_gui.emdataitem3d import EMDataItem3D, EMIsosurface
+from eman2_gui.emshape import EMShape
+from eman2_gui.valslider import ValSlider, ValBox
 
 	
 def run(cmd):

--- a/examples/e2spt_boxer22.py
+++ b/examples/e2spt_boxer22.py
@@ -42,13 +42,13 @@ import numpy as np
 import weakref
 from PyQt4 import QtCore, QtGui
 from PyQt4.QtCore import Qt
-from emapplication import get_application, EMApp
-from emimage2d import EMImage2DWidget
-from emimagemx import EMImageMXWidget
-from emimage3d import EMImage3DWidget
-from emscene3d import EMScene3D
-from emdataitem3d import EMDataItem3D, EMIsosurface
-from emshape import EMShape
+from qtgui.emapplication import get_application, EMApp
+from qtgui.emimage2d import EMImage2DWidget
+from qtgui.emimagemx import EMImageMXWidget
+from qtgui.emimage3d import EMImage3DWidget
+from qtgui.emscene3d import EMScene3D
+from qtgui.emdataitem3d import EMDataItem3D, EMIsosurface
+from qtgui.emshape import EMShape
 from valslider import ValSlider, ValBox
 
 	

--- a/examples/e2spt_boxer_old.py
+++ b/examples/e2spt_boxer_old.py
@@ -44,13 +44,13 @@ from EMAN2 import *
 '''
 from PyQt4 import QtCore, QtGui
 from PyQt4.QtCore import Qt
-from emapplication import get_application, EMApp
-from emimage2d import EMImage2DWidget
-from emimagemx import EMImageMXWidget
-from emimage3d import EMImage3DWidget
-from emscene3d import EMScene3D
-from emdataitem3d import EMDataItem3D, EMIsosurface
-from emshape import EMShape
+from qtgui.emapplication import get_application, EMApp
+from qtgui.emimage2d import EMImage2DWidget
+from qtgui.emimagemx import EMImageMXWidget
+from qtgui.emimage3d import EMImage3DWidget
+from qtgui.emscene3d import EMScene3D
+from qtgui.emdataitem3d import EMDataItem3D, EMIsosurface
+from qtgui.emshape import EMShape
 '''
 #from valslider import *
 
@@ -205,13 +205,13 @@ def main():
 		'''
 		from PyQt4 import QtCore, QtGui
 		from PyQt4.QtCore import Qt
-		from emapplication import get_application, EMApp
-		from emimage2d import EMImage2DWidget
-		from emimagemx import EMImageMXWidget
-		from emimage3d import EMImage3DWidget
-		from emscene3d import EMScene3D
-		from emdataitem3d import EMDataItem3D, EMIsosurface
-		from emshape import EMShape
+		from qtgui.emapplication import get_application, EMApp
+		from qtgui.emimage2d import EMImage2DWidget
+		from qtgui.emimagemx import EMImageMXWidget
+		from qtgui.emimage3d import EMImage3DWidget
+		from qtgui.emscene3d import EMScene3D
+		from qtgui.emdataitem3d import EMDataItem3D, EMIsosurface
+		from qtgui.emshape import EMShape
 
 
 		if options.path and options.verbose:
@@ -920,13 +920,13 @@ def sptboxergui(options,args):
 
 	from PyQt4 import QtCore, QtGui
 	from PyQt4.QtCore import Qt
-	from emapplication import get_application, EMApp
-	from emimage2d import EMImage2DWidget
-	from emimagemx import EMImageMXWidget
-	from emimage3d import EMImage3DWidget
-	from emscene3d import EMScene3D
-	from emdataitem3d import EMDataItem3D, EMIsosurface
-	from emshape import EMShape
+	from qtgui.emapplication import get_application, EMApp
+	from qtgui.emimage2d import EMImage2DWidget
+	from qtgui.emimagemx import EMImageMXWidget
+	from qtgui.emimage3d import EMImage3DWidget
+	from qtgui.emscene3d import EMScene3D
+	from qtgui.emdataitem3d import EMDataItem3D, EMIsosurface
+	from qtgui.emshape import EMShape
 	from valslider import ValSlider, ValBox
 
 	class EMAverageViewer(QtGui.QWidget):

--- a/examples/e2spt_boxer_old.py
+++ b/examples/e2spt_boxer_old.py
@@ -52,7 +52,7 @@ from qtgui.emscene3d import EMScene3D
 from qtgui.emdataitem3d import EMDataItem3D, EMIsosurface
 from qtgui.emshape import EMShape
 '''
-#from valslider import *
+#from qtgui.valslider import *
 
 
 from sys import argv
@@ -927,7 +927,7 @@ def sptboxergui(options,args):
 	from qtgui.emscene3d import EMScene3D
 	from qtgui.emdataitem3d import EMDataItem3D, EMIsosurface
 	from qtgui.emshape import EMShape
-	from valslider import ValSlider, ValBox
+	from qtgui.valslider import ValSlider, ValBox
 
 	class EMAverageViewer(QtGui.QWidget):
 		"""This is a multi-paned view showing a single boxed out particle from a larger tomogram"""

--- a/examples/e2spt_boxer_old.py
+++ b/examples/e2spt_boxer_old.py
@@ -44,15 +44,15 @@ from EMAN2 import *
 '''
 from PyQt4 import QtCore, QtGui
 from PyQt4.QtCore import Qt
-from qtgui.emapplication import get_application, EMApp
-from qtgui.emimage2d import EMImage2DWidget
-from qtgui.emimagemx import EMImageMXWidget
-from qtgui.emimage3d import EMImage3DWidget
-from qtgui.emscene3d import EMScene3D
-from qtgui.emdataitem3d import EMDataItem3D, EMIsosurface
-from qtgui.emshape import EMShape
+from eman2_gui.emapplication import get_application, EMApp
+from eman2_gui.emimage2d import EMImage2DWidget
+from eman2_gui.emimagemx import EMImageMXWidget
+from eman2_gui.emimage3d import EMImage3DWidget
+from eman2_gui.emscene3d import EMScene3D
+from eman2_gui.emdataitem3d import EMDataItem3D, EMIsosurface
+from eman2_gui.emshape import EMShape
 '''
-#from qtgui.valslider import *
+#from eman2_gui.valslider import *
 
 
 from sys import argv
@@ -205,13 +205,13 @@ def main():
 		'''
 		from PyQt4 import QtCore, QtGui
 		from PyQt4.QtCore import Qt
-		from qtgui.emapplication import get_application, EMApp
-		from qtgui.emimage2d import EMImage2DWidget
-		from qtgui.emimagemx import EMImageMXWidget
-		from qtgui.emimage3d import EMImage3DWidget
-		from qtgui.emscene3d import EMScene3D
-		from qtgui.emdataitem3d import EMDataItem3D, EMIsosurface
-		from qtgui.emshape import EMShape
+		from eman2_gui.emapplication import get_application, EMApp
+		from eman2_gui.emimage2d import EMImage2DWidget
+		from eman2_gui.emimagemx import EMImageMXWidget
+		from eman2_gui.emimage3d import EMImage3DWidget
+		from eman2_gui.emscene3d import EMScene3D
+		from eman2_gui.emdataitem3d import EMDataItem3D, EMIsosurface
+		from eman2_gui.emshape import EMShape
 
 
 		if options.path and options.verbose:
@@ -920,14 +920,14 @@ def sptboxergui(options,args):
 
 	from PyQt4 import QtCore, QtGui
 	from PyQt4.QtCore import Qt
-	from qtgui.emapplication import get_application, EMApp
-	from qtgui.emimage2d import EMImage2DWidget
-	from qtgui.emimagemx import EMImageMXWidget
-	from qtgui.emimage3d import EMImage3DWidget
-	from qtgui.emscene3d import EMScene3D
-	from qtgui.emdataitem3d import EMDataItem3D, EMIsosurface
-	from qtgui.emshape import EMShape
-	from qtgui.valslider import ValSlider, ValBox
+	from eman2_gui.emapplication import get_application, EMApp
+	from eman2_gui.emimage2d import EMImage2DWidget
+	from eman2_gui.emimagemx import EMImageMXWidget
+	from eman2_gui.emimage3d import EMImage3DWidget
+	from eman2_gui.emscene3d import EMScene3D
+	from eman2_gui.emdataitem3d import EMDataItem3D, EMIsosurface
+	from eman2_gui.emshape import EMShape
+	from eman2_gui.valslider import ValSlider, ValBox
 
 	class EMAverageViewer(QtGui.QWidget):
 		"""This is a multi-paned view showing a single boxed out particle from a larger tomogram"""

--- a/examples/e2tomoseg.py
+++ b/examples/e2tomoseg.py
@@ -32,11 +32,11 @@ from __future__ import print_function
 #
 
 from EMAN2 import *
-from emapplication import EMApp
-from emdataitem3d import EMDataItem3D, EMIsosurface
-from emimage2d import EMImage2DWidget
-from emimagemx import EMImageMXWidget
-from emscene3d import EMScene3D, EMInspector3D, EMQTreeWidget
+from qtgui.emapplication import EMApp
+from qtgui.emdataitem3d import EMDataItem3D, EMIsosurface
+from qtgui.emimage2d import EMImage2DWidget
+from qtgui.emimagemx import EMImageMXWidget
+from qtgui.emscene3d import EMScene3D, EMInspector3D, EMQTreeWidget
 import os
 from valslider import ValSlider, EMANToolButton, EMSpinWidget, EMQTColorWidget
 import weakref

--- a/examples/e2tomoseg.py
+++ b/examples/e2tomoseg.py
@@ -38,7 +38,7 @@ from qtgui.emimage2d import EMImage2DWidget
 from qtgui.emimagemx import EMImageMXWidget
 from qtgui.emscene3d import EMScene3D, EMInspector3D, EMQTreeWidget
 import os
-from valslider import ValSlider, EMANToolButton, EMSpinWidget, EMQTColorWidget
+from qtgui.valslider import ValSlider, EMANToolButton, EMSpinWidget, EMQTColorWidget
 import weakref
 
 from PyQt4 import QtCore

--- a/examples/e2tomoseg.py
+++ b/examples/e2tomoseg.py
@@ -32,13 +32,13 @@ from __future__ import print_function
 #
 
 from EMAN2 import *
-from qtgui.emapplication import EMApp
-from qtgui.emdataitem3d import EMDataItem3D, EMIsosurface
-from qtgui.emimage2d import EMImage2DWidget
-from qtgui.emimagemx import EMImageMXWidget
-from qtgui.emscene3d import EMScene3D, EMInspector3D, EMQTreeWidget
+from eman2_gui.emapplication import EMApp
+from eman2_gui.emdataitem3d import EMDataItem3D, EMIsosurface
+from eman2_gui.emimage2d import EMImage2DWidget
+from eman2_gui.emimagemx import EMImageMXWidget
+from eman2_gui.emscene3d import EMScene3D, EMInspector3D, EMQTreeWidget
 import os
-from qtgui.valslider import ValSlider, EMANToolButton, EMSpinWidget, EMQTColorWidget
+from eman2_gui.valslider import ValSlider, EMANToolButton, EMSpinWidget, EMQTColorWidget
 import weakref
 
 from PyQt4 import QtCore

--- a/examples/em_sim.py
+++ b/examples/em_sim.py
@@ -7,11 +7,11 @@ from OpenGL.GL import *
 from OpenGL.GLU import *
 from PyQt4 import QtGui, QtCore, QtOpenGL
 from PyQt4.QtCore import Qt
-from qtgui.emimage2d import EMImage2DWidget
+from eman2_gui.emimage2d import EMImage2DWidget
 from EMAN2 import *
-from qtgui.emapplication import EMApp
-from qtgui.emshape import EMShape
-from qtgui.emplot2d import EMPlot2DWidget
+from eman2_gui.emapplication import EMApp
+from eman2_gui.emshape import EMShape
+from eman2_gui.emplot2d import EMPlot2DWidget
 
 
 

--- a/examples/em_sim.py
+++ b/examples/em_sim.py
@@ -7,11 +7,11 @@ from OpenGL.GL import *
 from OpenGL.GLU import *
 from PyQt4 import QtGui, QtCore, QtOpenGL
 from PyQt4.QtCore import Qt
-from emimage2d import EMImage2DWidget
+from qtgui.emimage2d import EMImage2DWidget
 from EMAN2 import *
-from emapplication import EMApp
-from emshape import EMShape
-from emplot2d import EMPlot2DWidget
+from qtgui.emapplication import EMApp
+from qtgui.emshape import EMShape
+from qtgui.emplot2d import EMPlot2DWidget
 
 
 

--- a/examples/makebigfromseq.py
+++ b/examples/makebigfromseq.py
@@ -42,7 +42,7 @@ import sys
 from math import *
 try:
 	import wx
-	from qtgui.emimage import *
+	from eman2_gui.emimage import *
 except:
 	print("no wx")
 

--- a/examples/makebigfromseq.py
+++ b/examples/makebigfromseq.py
@@ -42,7 +42,7 @@ import sys
 from math import *
 try:
 	import wx
-	from emimage import *
+	from qtgui.emimage import *
 except:
 	print("no wx")
 

--- a/examples/morphboxer.py
+++ b/examples/morphboxer.py
@@ -350,7 +350,7 @@ class ErasingPanel: # copied for ideas for the morph panel
 
 			hbl = QtGui.QHBoxLayout()
 			hbl.addWidget(QtGui.QLabel("Erase Radius:"))
-			from valslider import ValSlider
+			from qtgui.valslider import ValSlider
 			self.erase_rad_edit = ValSlider(None,(0.0,1000.0),"")
 			self.erase_rad_edit.setValue(int(self.erase_radius))
 			self.erase_rad_edit.setEnabled(True)

--- a/examples/morphboxer.py
+++ b/examples/morphboxer.py
@@ -33,7 +33,7 @@ from __future__ import print_function
 
 from EMAN2 import *
 import sys
-from emboxerbase import *
+from qtgui.emboxerbase import *
 import subprocess as sp
 
 def main():

--- a/examples/morphboxer.py
+++ b/examples/morphboxer.py
@@ -33,7 +33,7 @@ from __future__ import print_function
 
 from EMAN2 import *
 import sys
-from qtgui.emboxerbase import *
+from eman2_gui.emboxerbase import *
 import subprocess as sp
 
 def main():
@@ -350,7 +350,7 @@ class ErasingPanel: # copied for ideas for the morph panel
 
 			hbl = QtGui.QHBoxLayout()
 			hbl.addWidget(QtGui.QLabel("Erase Radius:"))
-			from qtgui.valslider import ValSlider
+			from eman2_gui.valslider import ValSlider
 			self.erase_rad_edit = ValSlider(None,(0.0,1000.0),"")
 			self.erase_rad_edit.setValue(int(self.erase_radius))
 			self.erase_rad_edit.setEnabled(True)

--- a/examples/telescope.py
+++ b/examples/telescope.py
@@ -32,7 +32,7 @@ from __future__ import print_function
 #
 
 from EMAN2 import *
-from emimage import *
+from qtgui.emimage import *
 import time
 
 def live():

--- a/examples/telescope.py
+++ b/examples/telescope.py
@@ -32,7 +32,7 @@ from __future__ import print_function
 #
 
 from EMAN2 import *
-from qtgui.emimage import *
+from eman2_gui.emimage import *
 import time
 
 def live():

--- a/examples/timerdemo.py
+++ b/examples/timerdemo.py
@@ -34,8 +34,8 @@ from __future__ import print_function
 
 from EMAN2 import *
 from PyQt4 import QtCore
-from emapplication import EMApp
-from emimage2d import EMImage2DWidget
+from qtgui.emapplication import EMApp
+from qtgui.emimage2d import EMImage2DWidget
 
 def main():
 	global cur_data,data,imdisp

--- a/examples/timerdemo.py
+++ b/examples/timerdemo.py
@@ -34,8 +34,8 @@ from __future__ import print_function
 
 from EMAN2 import *
 from PyQt4 import QtCore
-from qtgui.emapplication import EMApp
-from qtgui.emimage2d import EMImage2DWidget
+from eman2_gui.emapplication import EMApp
+from eman2_gui.emimage2d import EMImage2DWidget
 
 def main():
 	global cur_data,data,imdisp

--- a/examples/tomotrackbox.py
+++ b/examples/tomotrackbox.py
@@ -35,12 +35,12 @@ from optparse import OptionParser
 import sys
 import os
 from EMAN2 import *
-from qtgui.emapplication import EMApp
-from qtgui.emimage2d import EMImage2DWidget
-from qtgui.emimage3d import EMImage3DModule
-from qtgui.valslider import ValSlider
+from eman2_gui.emapplication import EMApp
+from eman2_gui.emimage2d import EMImage2DWidget
+from eman2_gui.emimage3d import EMImage3DModule
+from eman2_gui.valslider import ValSlider
 import weakref
-from qtgui.emshape import EMShape
+from eman2_gui.emshape import EMShape
 from PyQt4 import QtCore, QtGui
 from PyQt4.QtCore import Qt
 #import EMAN2db

--- a/examples/tomotrackbox.py
+++ b/examples/tomotrackbox.py
@@ -35,12 +35,12 @@ from optparse import OptionParser
 import sys
 import os
 from EMAN2 import *
-from emapplication import EMApp
-from emimage2d import EMImage2DWidget
-from emimage3d import EMImage3DModule
+from qtgui.emapplication import EMApp
+from qtgui.emimage2d import EMImage2DWidget
+from qtgui.emimage3d import EMImage3DModule
 from valslider import ValSlider
 import weakref
-from emshape import EMShape
+from qtgui.emshape import EMShape
 from PyQt4 import QtCore, QtGui
 from PyQt4.QtCore import Qt
 #import EMAN2db

--- a/examples/tomotrackbox.py
+++ b/examples/tomotrackbox.py
@@ -38,7 +38,7 @@ from EMAN2 import *
 from qtgui.emapplication import EMApp
 from qtgui.emimage2d import EMImage2DWidget
 from qtgui.emimage3d import EMImage3DModule
-from valslider import ValSlider
+from qtgui.valslider import ValSlider
 import weakref
 from qtgui.emshape import EMShape
 from PyQt4 import QtCore, QtGui

--- a/libpyEM/EMAN2.py
+++ b/libpyEM/EMAN2.py
@@ -778,7 +778,7 @@ def euler_display(emdata_list):
 
 def browse():
 	if GUIMode:
-		from qtgui.emselector import EMBrowser
+		from eman2_gui.emselector import EMBrowser
 		browser = EMBrowser()
 		browser.show()
 		#app.attach_child(browser)
@@ -822,7 +822,7 @@ def plot_image_similarity(im1,im2,skipzero=True,skipnearzero=False):
 def plot(data,data2=None,data3=None,show=1,size=(800,600),path="plot.png"):
 	"""plots an image or an array using the matplotlib library"""
 	if GUIMode:
-		from qtgui.emplot2d import EMPlot2DWidget
+		from eman2_gui.emplot2d import EMPlot2DWidget
 		plotw=EMPlot2DWidget(application=app)
 		plotw.set_data(data,"interactive")
 		if data2!=None : plotw.set_data(data2,"interactive2")

--- a/libpyEM/EMAN2.py
+++ b/libpyEM/EMAN2.py
@@ -778,7 +778,7 @@ def euler_display(emdata_list):
 
 def browse():
 	if GUIMode:
-		from emselector import EMBrowser
+		from qtgui.emselector import EMBrowser
 		browser = EMBrowser()
 		browser.show()
 		#app.attach_child(browser)
@@ -822,7 +822,7 @@ def plot_image_similarity(im1,im2,skipzero=True,skipnearzero=False):
 def plot(data,data2=None,data3=None,show=1,size=(800,600),path="plot.png"):
 	"""plots an image or an array using the matplotlib library"""
 	if GUIMode:
-		from emplot2d import EMPlot2DWidget
+		from qtgui.emplot2d import EMPlot2DWidget
 		plotw=EMPlot2DWidget(application=app)
 		plotw.set_data(data,"interactive")
 		if data2!=None : plotw.set_data(data2,"interactive2")

--- a/libpyEM/EMAN2.py
+++ b/libpyEM/EMAN2.py
@@ -732,7 +732,7 @@ def display(img,force_2d=False,force_plot=False):
 	"""Generic display function for images or sets of images. You can force images to be displayed in 2-D or as a plot with
 	the optional flags"""
 	if GUIMode:
-		from qtgui import emimage
+		from eman2_gui import emimage
 		if isinstance(img,tuple) : img=list(img)
 		image = emimage.EMImageWidget(img,None,app,force_2d,force_plot)
 		image.show()
@@ -793,7 +793,7 @@ class EMImage(object):
 		old= is provided, and of the appropriate type, it will be used rather than creating
 		a new instance."""
 		if GUIMode:
-			from qtgui import emimage
+			from eman2_gui import emimage
 			image = emimage.EMImageWidget(data,old,app)
 			image.show()
 			#app.show_specific(image)

--- a/libpyEM/EMAN2.py
+++ b/libpyEM/EMAN2.py
@@ -732,7 +732,7 @@ def display(img,force_2d=False,force_plot=False):
 	"""Generic display function for images or sets of images. You can force images to be displayed in 2-D or as a plot with
 	the optional flags"""
 	if GUIMode:
-		import emimage
+		from qtgui import emimage
 		if isinstance(img,tuple) : img=list(img)
 		image = emimage.EMImageWidget(img,None,app,force_2d,force_plot)
 		image.show()
@@ -793,7 +793,7 @@ class EMImage(object):
 		old= is provided, and of the appropriate type, it will be used rather than creating
 		a new instance."""
 		if GUIMode:
-			import emimage
+			from qtgui import emimage
 			image = emimage.EMImageWidget(data,old,app)
 			image.show()
 			#app.show_specific(image)

--- a/libpyEM/qtgui/CMakeLists.txt
+++ b/libpyEM/qtgui/CMakeLists.txt
@@ -3,6 +3,6 @@ FILE(GLOB qtguifiles "${CMAKE_CURRENT_SOURCE_DIR}/*.py")
 # MESSAGE("gui files: ${qtguifiles}")
 
 INSTALL(FILES ${qtguifiles}
-		DESTINATION  ${SP_DIR}
+		DESTINATION  ${SP_DIR}/qtgui
 		COMPONENT PythonFiles
 		)

--- a/libpyEM/qtgui/CMakeLists.txt
+++ b/libpyEM/qtgui/CMakeLists.txt
@@ -3,6 +3,6 @@ FILE(GLOB qtguifiles "${CMAKE_CURRENT_SOURCE_DIR}/*.py")
 # MESSAGE("gui files: ${qtguifiles}")
 
 INSTALL(FILES ${qtguifiles}
-		DESTINATION  ${SP_DIR}/qtgui
+		DESTINATION  ${SP_DIR}/eman2_gui
 		COMPONENT PythonFiles
 		)

--- a/programs/e2RCTboxer.py
+++ b/programs/e2RCTboxer.py
@@ -35,13 +35,13 @@ from __future__ import print_function
 from EMAN2 import *
 from EMAN2db import db_open_dict, db_close_dict, db_remove_dict
 from PyQt4 import QtCore
-from emapplication import EMApp
-from emimagemx import EMImageMXWidget
-from emimage2d import EMImage2DWidget
+from qtgui.emapplication import EMApp
+from qtgui.emimagemx import EMImageMXWidget
+from qtgui.emimage2d import EMImage2DWidget
 from pyemtbx.boxertools import BigImageCache
-from emrctstrategy import Strategy2IMGMan, Strategy2IMGPair
-from emrctboxergui import ControlPannel
-from emshape import EMShape
+from qtgui.emrctstrategy import Strategy2IMGMan, Strategy2IMGPair
+from qtgui.emrctboxergui import ControlPannel
+from qtgui.emshape import EMShape
 import os, sys, itertools
 
 EMBOXERRCT_DB = "e2boxercache/rctboxer.json"

--- a/programs/e2RCTboxer.py
+++ b/programs/e2RCTboxer.py
@@ -35,13 +35,13 @@ from __future__ import print_function
 from EMAN2 import *
 from EMAN2db import db_open_dict, db_close_dict, db_remove_dict
 from PyQt4 import QtCore
-from qtgui.emapplication import EMApp
-from qtgui.emimagemx import EMImageMXWidget
-from qtgui.emimage2d import EMImage2DWidget
+from eman2_gui.emapplication import EMApp
+from eman2_gui.emimagemx import EMImageMXWidget
+from eman2_gui.emimage2d import EMImage2DWidget
 from pyemtbx.boxertools import BigImageCache
-from qtgui.emrctstrategy import Strategy2IMGMan, Strategy2IMGPair
-from qtgui.emrctboxergui import ControlPannel
-from qtgui.emshape import EMShape
+from eman2_gui.emrctstrategy import Strategy2IMGMan, Strategy2IMGPair
+from eman2_gui.emrctboxergui import ControlPannel
+from eman2_gui.emshape import EMShape
 import os, sys, itertools
 
 EMBOXERRCT_DB = "e2boxercache/rctboxer.json"

--- a/programs/e2_real.py
+++ b/programs/e2_real.py
@@ -44,7 +44,7 @@ try:
 	if get_platform()=="Linux" and os.getenv("DISPLAY")==None: raise Exception
 
 	from PyQt4 import QtCore, QtGui, QtOpenGL
-	from emapplication import EMApp
+	from qtgui.emapplication import EMApp
 	#import IPython.lib.inputhook
 #	import IPython.lib.guisupport
 
@@ -57,7 +57,7 @@ try:
 	#if not IPython.lib.guisupport.is_event_loop_running_qt4():
 		#IPython.lib.guisupport.start_event_loop_qt4()
 	
-	from emimage import image_update
+	from qtgui.emimage import image_update
 
 	def ipy_on_timer():
 		image_update()

--- a/programs/e2_real.py
+++ b/programs/e2_real.py
@@ -44,7 +44,7 @@ try:
 	if get_platform()=="Linux" and os.getenv("DISPLAY")==None: raise Exception
 
 	from PyQt4 import QtCore, QtGui, QtOpenGL
-	from qtgui.emapplication import EMApp
+	from eman2_gui.emapplication import EMApp
 	#import IPython.lib.inputhook
 #	import IPython.lib.guisupport
 
@@ -57,7 +57,7 @@ try:
 	#if not IPython.lib.guisupport.is_event_loop_running_qt4():
 		#IPython.lib.guisupport.start_event_loop_qt4()
 	
-	from qtgui.emimage import image_update
+	from eman2_gui.emimage import image_update
 
 	def ipy_on_timer():
 		image_update()

--- a/programs/e2boxer.py
+++ b/programs/e2boxer.py
@@ -51,7 +51,7 @@ try:
 	from qtgui.emimage2d import EMImage2DWidget
 	from qtgui.emplot2d import EMPlot2DWidget
 	from qtgui.emimagemx import EMImageMXWidget
-	from valslider import ValSlider,CheckBox,ValBox
+	from qtgui.valslider import ValSlider,CheckBox,ValBox
 	from qtgui.emshape import EMShape
 except:
 	QtGui=nothing()

--- a/programs/e2boxer.py
+++ b/programs/e2boxer.py
@@ -276,7 +276,7 @@ def main():
 			print("=====================================")
 			print("ERROR: GUI mode unavailable without PyQt4")
 			sys.exit(1)
-		from emapplication import EMApp
+		from eman2_gui.emapplication import EMApp
 		app=EMApp()
 		gui=GUIBoxer(args,options.voltage,options.apix,options.cs,options.ac,options.boxsize,options.ptclsize,options.threads)
 		gui.show()

--- a/programs/e2boxer.py
+++ b/programs/e2boxer.py
@@ -48,11 +48,11 @@ class nothing:
 try: 
 	from PyQt4 import QtCore, QtGui
 	from PyQt4.QtCore import Qt
-	from qtgui.emimage2d import EMImage2DWidget
-	from qtgui.emplot2d import EMPlot2DWidget
-	from qtgui.emimagemx import EMImageMXWidget
-	from qtgui.valslider import ValSlider,CheckBox,ValBox
-	from qtgui.emshape import EMShape
+	from eman2_gui.emimage2d import EMImage2DWidget
+	from eman2_gui.emplot2d import EMPlot2DWidget
+	from eman2_gui.emimagemx import EMImageMXWidget
+	from eman2_gui.valslider import ValSlider,CheckBox,ValBox
+	from eman2_gui.emshape import EMShape
 except:
 	QtGui=nothing()
 	QtCore=nothing()

--- a/programs/e2boxer.py
+++ b/programs/e2boxer.py
@@ -48,11 +48,11 @@ class nothing:
 try: 
 	from PyQt4 import QtCore, QtGui
 	from PyQt4.QtCore import Qt
-	from emimage2d import EMImage2DWidget
-	from emplot2d import EMPlot2DWidget
-	from emimagemx import EMImageMXWidget
+	from qtgui.emimage2d import EMImage2DWidget
+	from qtgui.emplot2d import EMPlot2DWidget
+	from qtgui.emimagemx import EMImageMXWidget
 	from valslider import ValSlider,CheckBox,ValBox
-	from emshape import EMShape
+	from qtgui.emshape import EMShape
 except:
 	QtGui=nothing()
 	QtCore=nothing()

--- a/programs/e2boxer_old.py
+++ b/programs/e2boxer_old.py
@@ -38,7 +38,7 @@ from EMAN2jsondb import *
 from pyemtbx.boxertools import CoarsenedFlattenedImageCache,FLCFImageCache
 from copy import deepcopy
 from EMAN2 import *
-from qtgui.emboxerbase import *
+from eman2_gui.emboxerbase import *
 import os
 
 SWARM_TEMPLATE_MIN = TEMPLATE_MIN # this comes from emboxerbase
@@ -590,7 +590,7 @@ class SwarmPanel:
 			self.enable_interactive_threshold  = QtGui.QCheckBox("Interactive Threshold")
 			self.enable_interactive_threshold.setToolTip("Tweak the correlation threshold that is used to select particles.")
 			self.enable_interactive_threshold.setChecked(False)
-			from qtgui.valslider import ValSlider
+			from eman2_gui.valslider import ValSlider
 			self.thr = ValSlider(None,(0.0,3.0),"")
 			self.thr.setValue(1.0)
 			self.thr.setEnabled(False)
@@ -1258,7 +1258,7 @@ class SwarmBoxer:
 		Brings the template viewer to the foreground
 		'''
 		if self.template_viewer == None:
-			from qtgui.emimagemx import EMImageMXWidget
+			from eman2_gui.emimagemx import EMImageMXWidget
 			self.template_viewer = EMImageMXWidget()
 
 			self.template_viewer.set_data(self.templates,soft_delete=True) # should work if self.templates is None

--- a/programs/e2boxer_old.py
+++ b/programs/e2boxer_old.py
@@ -590,7 +590,7 @@ class SwarmPanel:
 			self.enable_interactive_threshold  = QtGui.QCheckBox("Interactive Threshold")
 			self.enable_interactive_threshold.setToolTip("Tweak the correlation threshold that is used to select particles.")
 			self.enable_interactive_threshold.setChecked(False)
-			from valslider import ValSlider
+			from qtgui.valslider import ValSlider
 			self.thr = ValSlider(None,(0.0,3.0),"")
 			self.thr.setValue(1.0)
 			self.thr.setEnabled(False)

--- a/programs/e2boxer_old.py
+++ b/programs/e2boxer_old.py
@@ -38,7 +38,7 @@ from EMAN2jsondb import *
 from pyemtbx.boxertools import CoarsenedFlattenedImageCache,FLCFImageCache
 from copy import deepcopy
 from EMAN2 import *
-from emboxerbase import *
+from qtgui.emboxerbase import *
 import os
 
 SWARM_TEMPLATE_MIN = TEMPLATE_MIN # this comes from emboxerbase
@@ -1258,7 +1258,7 @@ class SwarmBoxer:
 		Brings the template viewer to the foreground
 		'''
 		if self.template_viewer == None:
-			from emimagemx import EMImageMXWidget
+			from qtgui.emimagemx import EMImageMXWidget
 			self.template_viewer = EMImageMXWidget()
 
 			self.template_viewer.set_data(self.templates,soft_delete=True) # should work if self.templates is None

--- a/programs/e2cmpxplor.py
+++ b/programs/e2cmpxplor.py
@@ -32,13 +32,13 @@ from __future__ import print_function
 #
 #
 
-from emapplication import EMApp, get_application
-from emimage3dsym import EM3DSymModel,EMSymInspector
+from qtgui.emapplication import EMApp, get_application
+from qtgui.emimage3dsym import EM3DSymModel,EMSymInspector
 import os,sys
 from EMAN2 import *
 from PyQt4 import QtGui,QtCore
-from emimagemx import EMImageMXModule
-from emglobjects import EM3DGLWidget
+from qtgui.emimagemx import EMImageMXModule
+from qtgui.emglobjects import EM3DGLWidget
 
 	
 def main():

--- a/programs/e2cmpxplor.py
+++ b/programs/e2cmpxplor.py
@@ -32,13 +32,13 @@ from __future__ import print_function
 #
 #
 
-from qtgui.emapplication import EMApp, get_application
-from qtgui.emimage3dsym import EM3DSymModel,EMSymInspector
+from eman2_gui.emapplication import EMApp, get_application
+from eman2_gui.emimage3dsym import EM3DSymModel,EMSymInspector
 import os,sys
 from EMAN2 import *
 from PyQt4 import QtGui,QtCore
-from qtgui.emimagemx import EMImageMXModule
-from qtgui.emglobjects import EM3DGLWidget
+from eman2_gui.emimagemx import EMImageMXModule
+from eman2_gui.emglobjects import EM3DGLWidget
 
 	
 def main():

--- a/programs/e2ctf.py
+++ b/programs/e2ctf.py
@@ -2255,7 +2255,7 @@ try:
 	from PyQt4.QtCore import Qt
 	from OpenGL import GL,GLUT
 	from qtgui.emshape import *
-	from valslider import ValSlider,CheckBox
+	from qtgui.valslider import ValSlider,CheckBox
 except:
 	print("Warning: PyQt4 must be installed to use the --gui option")
 	class dummy:

--- a/programs/e2ctf.py
+++ b/programs/e2ctf.py
@@ -264,7 +264,7 @@ NOTE: This program should be run from the project directory, not from within the
 		if len(img_sets) == 0:
 			if not options.chunk: E2end(logid)
 			exit(1)
-		from qtgui.emapplication import EMApp
+		from eman2_gui.emapplication import EMApp
 		app=EMApp()
 		gui=GUIctf(app,img_sets,options.autohp,options.nosmooth)
 		gui.show_guis()
@@ -2254,8 +2254,8 @@ try:
 	from PyQt4 import QtCore, QtGui, QtOpenGL
 	from PyQt4.QtCore import Qt
 	from OpenGL import GL,GLUT
-	from qtgui.emshape import *
-	from qtgui.valslider import ValSlider,CheckBox
+	from eman2_gui.emshape import *
+	from eman2_gui.valslider import ValSlider,CheckBox
 except:
 	print("Warning: PyQt4 must be installed to use the --gui option")
 	class dummy:
@@ -2295,12 +2295,12 @@ class GUIctf(QtGui.QWidget):
 		'data' is a list of (filename,EMAN2CTF,im_1d,bg_1d,im_2d,bg_2d,qual,bg_1d_low)
 		"""
 		try:
-			from qtgui.emimage2d import EMImage2DWidget
+			from eman2_gui.emimage2d import EMImage2DWidget
 		except:
 			print("Cannot import EMAN image GUI objects (EMImage2DWidget)")
 			sys.exit(1)
 		try:
-			from qtgui.emplot2d import EMPlot2DWidget
+			from eman2_gui.emplot2d import EMPlot2DWidget
 		except:
 			print("Cannot import EMAN plot GUI objects (is matplotlib installed?)")
 			sys.exit(1)
@@ -2551,7 +2551,7 @@ class GUIctf(QtGui.QWidget):
 		self.newSet(self.curset)
 
 	def on_output(self):
-		from qtgui.emsprworkflow import E2CTFOutputTaskGeneral
+		from eman2_gui.emsprworkflow import E2CTFOutputTaskGeneral
 
 		n = self.setlist.count()
 		names = [str(self.setlist.item(i).text()) for i in xrange(0,n)]

--- a/programs/e2ctf.py
+++ b/programs/e2ctf.py
@@ -264,7 +264,7 @@ NOTE: This program should be run from the project directory, not from within the
 		if len(img_sets) == 0:
 			if not options.chunk: E2end(logid)
 			exit(1)
-		from emapplication import EMApp
+		from qtgui.emapplication import EMApp
 		app=EMApp()
 		gui=GUIctf(app,img_sets,options.autohp,options.nosmooth)
 		gui.show_guis()
@@ -2254,7 +2254,7 @@ try:
 	from PyQt4 import QtCore, QtGui, QtOpenGL
 	from PyQt4.QtCore import Qt
 	from OpenGL import GL,GLUT
-	from emshape import *
+	from qtgui.emshape import *
 	from valslider import ValSlider,CheckBox
 except:
 	print("Warning: PyQt4 must be installed to use the --gui option")
@@ -2295,12 +2295,12 @@ class GUIctf(QtGui.QWidget):
 		'data' is a list of (filename,EMAN2CTF,im_1d,bg_1d,im_2d,bg_2d,qual,bg_1d_low)
 		"""
 		try:
-			from emimage2d import EMImage2DWidget
+			from qtgui.emimage2d import EMImage2DWidget
 		except:
 			print("Cannot import EMAN image GUI objects (EMImage2DWidget)")
 			sys.exit(1)
 		try:
-			from emplot2d import EMPlot2DWidget
+			from qtgui.emplot2d import EMPlot2DWidget
 		except:
 			print("Cannot import EMAN plot GUI objects (is matplotlib installed?)")
 			sys.exit(1)
@@ -2551,7 +2551,7 @@ class GUIctf(QtGui.QWidget):
 		self.newSet(self.curset)
 
 	def on_output(self):
-		from emsprworkflow import E2CTFOutputTaskGeneral
+		from qtgui.emsprworkflow import E2CTFOutputTaskGeneral
 
 		n = self.setlist.count()
 		names = [str(self.setlist.item(i).text()) for i in xrange(0,n)]

--- a/programs/e2ctfsim.py
+++ b/programs/e2ctfsim.py
@@ -78,7 +78,7 @@ A simple CTF simulation program.
 try:
 	from PyQt4 import QtCore, QtGui, QtOpenGL
 	from PyQt4.QtCore import Qt
-	from emshape import *
+	from qtgui.emshape import *
 	from valslider import ValSlider
 except:
 	print("Error: PyQt4 must be installed")
@@ -102,12 +102,12 @@ class GUIctfsim(QtGui.QWidget):
 		"""CTF simulation dialog
 		"""
 		try:
-			from emimage2d import EMImage2DWidget
+			from qtgui.emimage2d import EMImage2DWidget
 		except:
 			print("Cannot import EMAN image GUI objects (EMImage2DWidget)")
 			sys.exit(1)
 		try:
-			from emplot2d import EMPlot2DWidget
+			from qtgui.emplot2d import EMPlot2DWidget
 		except:
 			print("Cannot import EMAN plot GUI objects (is matplotlib installed?)")
 			sys.exit(1)

--- a/programs/e2ctfsim.py
+++ b/programs/e2ctfsim.py
@@ -78,8 +78,8 @@ A simple CTF simulation program.
 try:
 	from PyQt4 import QtCore, QtGui, QtOpenGL
 	from PyQt4.QtCore import Qt
-	from qtgui.emshape import *
-	from qtgui.valslider import ValSlider
+	from eman2_gui.emshape import *
+	from eman2_gui.valslider import ValSlider
 except:
 	print("Error: PyQt4 must be installed")
 	sys.exit(1)
@@ -102,12 +102,12 @@ class GUIctfsim(QtGui.QWidget):
 		"""CTF simulation dialog
 		"""
 		try:
-			from qtgui.emimage2d import EMImage2DWidget
+			from eman2_gui.emimage2d import EMImage2DWidget
 		except:
 			print("Cannot import EMAN image GUI objects (EMImage2DWidget)")
 			sys.exit(1)
 		try:
-			from qtgui.emplot2d import EMPlot2DWidget
+			from eman2_gui.emplot2d import EMPlot2DWidget
 		except:
 			print("Cannot import EMAN plot GUI objects (is matplotlib installed?)")
 			sys.exit(1)

--- a/programs/e2ctfsim.py
+++ b/programs/e2ctfsim.py
@@ -66,7 +66,7 @@ A simple CTF simulation program.
 
 	(options, args) = parser.parse_args()
 
-	from emapplication import EMApp
+	from eman2_gui.emapplication import EMApp
 	app=EMApp()
 	gui=GUIctfsim(app,options.apix,options.voltage,options.cs,options.ac,options.samples,options.apply)
 	gui.show_guis()

--- a/programs/e2ctfsim.py
+++ b/programs/e2ctfsim.py
@@ -79,7 +79,7 @@ try:
 	from PyQt4 import QtCore, QtGui, QtOpenGL
 	from PyQt4.QtCore import Qt
 	from qtgui.emshape import *
-	from valslider import ValSlider
+	from qtgui.valslider import ValSlider
 except:
 	print("Error: PyQt4 must be installed")
 	sys.exit(1)

--- a/programs/e2display.py
+++ b/programs/e2display.py
@@ -34,10 +34,10 @@ from __future__ import print_function
 
 from EMAN2 import EMANVERSION, E2init, E2end, EMData, base_name, file_exists, EMArgumentParser
 import EMAN2db
-from emapplication import EMApp
+from qtgui.emapplication import EMApp
 from qtgui import embrowser
-from emimage import EMImageWidget, EMWidgetFromFile
-from emscene3d import EMScene3D
+from qtgui.emimage import EMImageWidget, EMWidgetFromFile
+from qtgui.emscene3d import EMScene3D
 import os
 import sys
 
@@ -250,7 +250,7 @@ def display(img,app,title="EMAN2 image"):
 	return w
 
 def plot(files,app):
-	from emplot2d import EMPlot2DWidget
+	from qtgui.emplot2d import EMPlot2DWidget
 	plotw=EMPlot2DWidget(application=app)
 	for f in files:
 		plotw.set_data_from_file(f,quiet=True)
@@ -259,7 +259,7 @@ def plot(files,app):
 	return plotw
 
 def hist(files,app):
-	from emhist import EMHistogramWidget
+	from qtgui.emhist import EMHistogramWidget
 	histw=EMHistogramWidget(application=app)
 	for f in files:
 		histw.set_data_from_file(f,quiet=True)
@@ -268,7 +268,7 @@ def hist(files,app):
 	return histw
 
 def plot_3d(files,app):
-	from emplot3d import EMPlot3DWidgetNew
+	from qtgui.emplot3d import EMPlot3DWidgetNew
 	plotw=EMPlot3DWidgetNew(application=app)
 	for f in files:
 		plotw.set_data_from_file(f)
@@ -277,7 +277,7 @@ def plot_3d(files,app):
 	return plotw
 
 def load_pdb(files,app):
-	from empdbitem3D import EMPDBItem3D, EMBallStickModel
+	from qtgui.empdbitem3D import EMPDBItem3D, EMBallStickModel
 	scene=EMScene3D()
 	title = []
 	for f in files:

--- a/programs/e2display.py
+++ b/programs/e2display.py
@@ -35,7 +35,7 @@ from __future__ import print_function
 from EMAN2 import EMANVERSION, E2init, E2end, EMData, base_name, file_exists, EMArgumentParser
 import EMAN2db
 from emapplication import EMApp
-import embrowser
+from qtgui import embrowser
 from emimage import EMImageWidget, EMWidgetFromFile
 from emscene3d import EMScene3D
 import os

--- a/programs/e2display.py
+++ b/programs/e2display.py
@@ -34,10 +34,10 @@ from __future__ import print_function
 
 from EMAN2 import EMANVERSION, E2init, E2end, EMData, base_name, file_exists, EMArgumentParser
 import EMAN2db
-from qtgui.emapplication import EMApp
+from eman2_gui.emapplication import EMApp
 from qtgui import embrowser
-from qtgui.emimage import EMImageWidget, EMWidgetFromFile
-from qtgui.emscene3d import EMScene3D
+from eman2_gui.emimage import EMImageWidget, EMWidgetFromFile
+from eman2_gui.emscene3d import EMScene3D
 import os
 import sys
 
@@ -250,7 +250,7 @@ def display(img,app,title="EMAN2 image"):
 	return w
 
 def plot(files,app):
-	from qtgui.emplot2d import EMPlot2DWidget
+	from eman2_gui.emplot2d import EMPlot2DWidget
 	plotw=EMPlot2DWidget(application=app)
 	for f in files:
 		plotw.set_data_from_file(f,quiet=True)
@@ -259,7 +259,7 @@ def plot(files,app):
 	return plotw
 
 def hist(files,app):
-	from qtgui.emhist import EMHistogramWidget
+	from eman2_gui.emhist import EMHistogramWidget
 	histw=EMHistogramWidget(application=app)
 	for f in files:
 		histw.set_data_from_file(f,quiet=True)
@@ -268,7 +268,7 @@ def hist(files,app):
 	return histw
 
 def plot_3d(files,app):
-	from qtgui.emplot3d import EMPlot3DWidgetNew
+	from eman2_gui.emplot3d import EMPlot3DWidgetNew
 	plotw=EMPlot3DWidgetNew(application=app)
 	for f in files:
 		plotw.set_data_from_file(f)
@@ -277,7 +277,7 @@ def plot_3d(files,app):
 	return plotw
 
 def load_pdb(files,app):
-	from qtgui.empdbitem3D import EMPDBItem3D, EMBallStickModel
+	from eman2_gui.empdbitem3D import EMPDBItem3D, EMBallStickModel
 	scene=EMScene3D()
 	title = []
 	for f in files:

--- a/programs/e2display.py
+++ b/programs/e2display.py
@@ -35,7 +35,7 @@ from __future__ import print_function
 from EMAN2 import EMANVERSION, E2init, E2end, EMData, base_name, file_exists, EMArgumentParser
 import EMAN2db
 from eman2_gui.emapplication import EMApp
-from qtgui import embrowser
+from eman2_gui import embrowser
 from eman2_gui.emimage import EMImageWidget, EMWidgetFromFile
 from eman2_gui.emscene3d import EMScene3D
 import os

--- a/programs/e2eulerxplor.py
+++ b/programs/e2eulerxplor.py
@@ -39,12 +39,12 @@ from OpenGL.GL import *
 from OpenGL.GLU import *
 from PyQt4 import QtGui,QtCore
 from PyQt4.QtCore import Qt
-from emanimationutil import OrientationListAnimation,Animator
-from emapplication import EMApp, get_application, error
-from emglobjects import EM3DModel
-from emimage2d import EMImage2DWidget
-from emimage3dsym import EM3DSymModel, EMSymInspector, EMSymViewerWidget
-from emimagemx import EMImageMXWidget, EMLightWeightParticleCache
+from qtgui.emanimationutil import OrientationListAnimation,Animator
+from qtgui.emapplication import EMApp, get_application, error
+from qtgui.emglobjects import EM3DModel
+from qtgui.emimage2d import EMImage2DWidget
+from qtgui.emimage3dsym import EM3DSymModel, EMSymInspector, EMSymViewerWidget
+from qtgui.emimagemx import EMImageMXWidget, EMLightWeightParticleCache
 import os
 import sys
 import weakref
@@ -414,7 +414,7 @@ class EMEulerExplorer(EM3DSymModel,Animator):
 		#eulers = s.gen_orientations("rand",{"n":EMUtil.get_image_count(self.average_file)})
 
 		self.specify_eulers(eulers)
-		#from emimagemx import EMDataListCache
+		#from qtgui.emimagemx import EMDataListCache
 		#a = EMData.read_images(self.average_file)
 		#a = [test_image() for i in range(EMUtil.get_image_count(self.average_file))]
 		#print len(a),len(eulers)
@@ -591,7 +591,7 @@ class EMEulerExplorer(EM3DSymModel,Animator):
 			data = []
 			idx_included = []
 			running_idx = 0
-			from emimagemx import ApplyAttribute
+			from qtgui.emimagemx import ApplyAttribute
 			for val in included:
 				bdata.append([self.particle_file,val,[ApplyAttribute("Img #",val)]])
 				idx_included.append(running_idx)
@@ -642,7 +642,7 @@ class EMEulerExplorer(EM3DSymModel,Animator):
 
 					t = Transform({"type":"2d","alpha":a,"mirror":int(m)})
 					t.set_trans(x,y)
-					from emimagemx import ApplyTransform
+					from qtgui.emimagemx import ApplyTransform
 					f.append(ApplyTransform(t))
 					#data[i].transform(t)
 				self.particle_viewer.set_data(data)

--- a/programs/e2eulerxplor.py
+++ b/programs/e2eulerxplor.py
@@ -39,12 +39,12 @@ from OpenGL.GL import *
 from OpenGL.GLU import *
 from PyQt4 import QtGui,QtCore
 from PyQt4.QtCore import Qt
-from qtgui.emanimationutil import OrientationListAnimation,Animator
-from qtgui.emapplication import EMApp, get_application, error
-from qtgui.emglobjects import EM3DModel
-from qtgui.emimage2d import EMImage2DWidget
-from qtgui.emimage3dsym import EM3DSymModel, EMSymInspector, EMSymViewerWidget
-from qtgui.emimagemx import EMImageMXWidget, EMLightWeightParticleCache
+from eman2_gui.emanimationutil import OrientationListAnimation,Animator
+from eman2_gui.emapplication import EMApp, get_application, error
+from eman2_gui.emglobjects import EM3DModel
+from eman2_gui.emimage2d import EMImage2DWidget
+from eman2_gui.emimage3dsym import EM3DSymModel, EMSymInspector, EMSymViewerWidget
+from eman2_gui.emimagemx import EMImageMXWidget, EMLightWeightParticleCache
 import os
 import sys
 import weakref
@@ -414,7 +414,7 @@ class EMEulerExplorer(EM3DSymModel,Animator):
 		#eulers = s.gen_orientations("rand",{"n":EMUtil.get_image_count(self.average_file)})
 
 		self.specify_eulers(eulers)
-		#from qtgui.emimagemx import EMDataListCache
+		#from eman2_gui.emimagemx import EMDataListCache
 		#a = EMData.read_images(self.average_file)
 		#a = [test_image() for i in range(EMUtil.get_image_count(self.average_file))]
 		#print len(a),len(eulers)
@@ -591,7 +591,7 @@ class EMEulerExplorer(EM3DSymModel,Animator):
 			data = []
 			idx_included = []
 			running_idx = 0
-			from qtgui.emimagemx import ApplyAttribute
+			from eman2_gui.emimagemx import ApplyAttribute
 			for val in included:
 				bdata.append([self.particle_file,val,[ApplyAttribute("Img #",val)]])
 				idx_included.append(running_idx)
@@ -642,7 +642,7 @@ class EMEulerExplorer(EM3DSymModel,Animator):
 
 					t = Transform({"type":"2d","alpha":a,"mirror":int(m)})
 					t.set_trans(x,y)
-					from qtgui.emimagemx import ApplyTransform
+					from eman2_gui.emimagemx import ApplyTransform
 					f.append(ApplyTransform(t))
 					#data[i].transform(t)
 				self.particle_viewer.set_data(data)

--- a/programs/e2evalimage.py
+++ b/programs/e2evalimage.py
@@ -48,7 +48,7 @@ try:
 	from PyQt4 import QtCore, QtGui, QtOpenGL
 	from PyQt4.QtCore import Qt
 	from PyQt4.QtCore import QTimer
-	from emshape import *
+	from qtgui.emshape import *
 	from valslider import *
 except:
 	print("Warning: PyQt4 must be installed")
@@ -122,12 +122,12 @@ class GUIEvalImage(QtGui.QWidget):
 		'parms' is [box size,ctf,box coord,set of excluded boxnums,quality,oversampling]
 		"""
 		try:
-			from emimage2d import EMImage2DWidget
+			from qtgui.emimage2d import EMImage2DWidget
 		except:
 			print("Cannot import EMAN image GUI objects (EMImage2DWidget)")
 			sys.exit(1)
 		try:
-			from emplot2d import EMPlot2DWidget
+			from qtgui.emplot2d import EMPlot2DWidget
 		except:
 			print("Cannot import EMAN plot GUI objects (is matplotlib installed?)")
 			sys.exit(1)

--- a/programs/e2evalimage.py
+++ b/programs/e2evalimage.py
@@ -48,8 +48,8 @@ try:
 	from PyQt4 import QtCore, QtGui, QtOpenGL
 	from PyQt4.QtCore import Qt
 	from PyQt4.QtCore import QTimer
-	from qtgui.emshape import *
-	from qtgui.valslider import *
+	from eman2_gui.emshape import *
+	from eman2_gui.valslider import *
 except:
 	print("Warning: PyQt4 must be installed")
 	sys.exit(1)
@@ -122,12 +122,12 @@ class GUIEvalImage(QtGui.QWidget):
 		'parms' is [box size,ctf,box coord,set of excluded boxnums,quality,oversampling]
 		"""
 		try:
-			from qtgui.emimage2d import EMImage2DWidget
+			from eman2_gui.emimage2d import EMImage2DWidget
 		except:
 			print("Cannot import EMAN image GUI objects (EMImage2DWidget)")
 			sys.exit(1)
 		try:
-			from qtgui.emplot2d import EMPlot2DWidget
+			from eman2_gui.emplot2d import EMPlot2DWidget
 		except:
 			print("Cannot import EMAN plot GUI objects (is matplotlib installed?)")
 			sys.exit(1)

--- a/programs/e2evalimage.py
+++ b/programs/e2evalimage.py
@@ -95,7 +95,7 @@ power spectrum in various ways."""
 
 	logid=E2init(sys.argv,options.ppid)
 
-	from emapplication import EMApp
+	from eman2_gui.emapplication import EMApp
 	app=EMApp()
 	gui=GUIEvalImage(args,options.voltage,options.apix,options.cs,options.ac,options.box,options.usefoldername,options.constbfactor,options.astigmatism,options.phaseplate)
 	gui.show()

--- a/programs/e2evalimage.py
+++ b/programs/e2evalimage.py
@@ -49,7 +49,7 @@ try:
 	from PyQt4.QtCore import Qt
 	from PyQt4.QtCore import QTimer
 	from qtgui.emshape import *
-	from valslider import *
+	from qtgui.valslider import *
 except:
 	print("Warning: PyQt4 must be installed")
 	sys.exit(1)

--- a/programs/e2evalparticles.py
+++ b/programs/e2evalparticles.py
@@ -42,7 +42,7 @@ from PyQt4.QtCore import Qt
 from qtgui.emapplication import EMApp
 import os
 from EMAN2db import *
-from valslider import *
+from qtgui.valslider import *
 import traceback
 
 def main():

--- a/programs/e2evalparticles.py
+++ b/programs/e2evalparticles.py
@@ -33,13 +33,13 @@ from __future__ import print_function
 
 #
 from EMAN2 import *
-from emimagemx import EMImageMXWidget
+from qtgui.emimagemx import EMImageMXWidget
 
 import sys
 from PyQt4 import QtCore, QtGui, QtOpenGL
 from PyQt4.QtCore import Qt
 #from OpenGL import GL,GLU,GLUT
-from emapplication import EMApp
+from qtgui.emapplication import EMApp
 import os
 from EMAN2db import *
 from valslider import *

--- a/programs/e2evalparticles.py
+++ b/programs/e2evalparticles.py
@@ -33,16 +33,16 @@ from __future__ import print_function
 
 #
 from EMAN2 import *
-from qtgui.emimagemx import EMImageMXWidget
+from eman2_gui.emimagemx import EMImageMXWidget
 
 import sys
 from PyQt4 import QtCore, QtGui, QtOpenGL
 from PyQt4.QtCore import Qt
 #from OpenGL import GL,GLU,GLUT
-from qtgui.emapplication import EMApp
+from eman2_gui.emapplication import EMApp
 import os
 from EMAN2db import *
-from qtgui.valslider import *
+from eman2_gui.valslider import *
 import traceback
 
 def main():

--- a/programs/e2fhstat.py
+++ b/programs/e2fhstat.py
@@ -33,10 +33,10 @@ from __future__ import print_function
 
 from EMAN2 import *
 from PyQt4 import QtCore
-from qtgui.emfoldhunterstat import *
-from qtgui.emapplication import get_application
-from qtgui.empdbvaltool import EMPDBValWidget
-from qtgui.emplot3d import *
+from eman2_gui.emfoldhunterstat import *
+from eman2_gui.emapplication import get_application
+from eman2_gui.empdbvaltool import EMPDBValWidget
+from eman2_gui.emplot3d import *
 import os
 
 class E2ValidateMed():
@@ -236,7 +236,7 @@ class E2ValidateMed():
 		#################################################
 
 if __name__ == '__main__':
-	from qtgui.emapplication import EMApp
+	from eman2_gui.emapplication import EMApp
 	em_app = EMApp()
 	window = E2ValidateMed()
 	window.start()

--- a/programs/e2fhstat.py
+++ b/programs/e2fhstat.py
@@ -33,10 +33,10 @@ from __future__ import print_function
 
 from EMAN2 import *
 from PyQt4 import QtCore
-from emfoldhunterstat import *
-from emapplication import get_application
-from empdbvaltool import EMPDBValWidget
-from emplot3d import *
+from qtgui.emfoldhunterstat import *
+from qtgui.emapplication import get_application
+from qtgui.empdbvaltool import EMPDBValWidget
+from qtgui.emplot3d import *
 import os
 
 class E2ValidateMed():
@@ -236,7 +236,7 @@ class E2ValidateMed():
 		#################################################
 
 if __name__ == '__main__':
-	from emapplication import EMApp
+	from qtgui.emapplication import EMApp
 	em_app = EMApp()
 	window = E2ValidateMed()
 	window.start()

--- a/programs/e2filtertool.py
+++ b/programs/e2filtertool.py
@@ -41,13 +41,13 @@ import weakref
 import threading
 
 from EMAN2 import *
-from emapplication import get_application, EMApp
-from emimage2d import EMImage2DWidget
-from emplot2d import EMPlot2DWidget
-from emimagemx import EMImageMXWidget
-from emscene3d import EMScene3D
-from emdataitem3d import EMDataItem3D, EMIsosurface, EMSliceItem3D
-from emshape import EMShape
+from qtgui.emapplication import get_application, EMApp
+from qtgui.emimage2d import EMImage2DWidget
+from qtgui.emplot2d import EMPlot2DWidget
+from qtgui.emimagemx import EMImageMXWidget
+from qtgui.emscene3d import EMScene3D
+from qtgui.emdataitem3d import EMDataItem3D, EMIsosurface, EMSliceItem3D
+from qtgui.emshape import EMShape
 from valslider import *
 import traceback
 

--- a/programs/e2filtertool.py
+++ b/programs/e2filtertool.py
@@ -41,14 +41,14 @@ import weakref
 import threading
 
 from EMAN2 import *
-from qtgui.emapplication import get_application, EMApp
-from qtgui.emimage2d import EMImage2DWidget
-from qtgui.emplot2d import EMPlot2DWidget
-from qtgui.emimagemx import EMImageMXWidget
-from qtgui.emscene3d import EMScene3D
-from qtgui.emdataitem3d import EMDataItem3D, EMIsosurface, EMSliceItem3D
-from qtgui.emshape import EMShape
-from qtgui.valslider import *
+from eman2_gui.emapplication import get_application, EMApp
+from eman2_gui.emimage2d import EMImage2DWidget
+from eman2_gui.emplot2d import EMPlot2DWidget
+from eman2_gui.emimagemx import EMImageMXWidget
+from eman2_gui.emscene3d import EMScene3D
+from eman2_gui.emdataitem3d import EMDataItem3D, EMIsosurface, EMSliceItem3D
+from eman2_gui.emshape import EMShape
+from eman2_gui.valslider import *
 import traceback
 
 def main():

--- a/programs/e2filtertool.py
+++ b/programs/e2filtertool.py
@@ -48,7 +48,7 @@ from qtgui.emimagemx import EMImageMXWidget
 from qtgui.emscene3d import EMScene3D
 from qtgui.emdataitem3d import EMDataItem3D, EMIsosurface, EMSliceItem3D
 from qtgui.emshape import EMShape
-from valslider import *
+from qtgui.valslider import *
 import traceback
 
 def main():

--- a/programs/e2helixboxer.py
+++ b/programs/e2helixboxer.py
@@ -41,10 +41,10 @@ import os
 
 try:
 	from PyQt4 import QtGui, QtCore
-	from qtgui.emapplication import EMApp, get_application
-	from qtgui.emimage2d import EMImage2DWidget
-	from qtgui.emselector import EMSelectorDialog
-	from qtgui.emshape import EMShape, EMShapeDict
+	from eman2_gui.emapplication import EMApp, get_application
+	from eman2_gui.emimage2d import EMImage2DWidget
+	from eman2_gui.emselector import EMSelectorDialog
+	from eman2_gui.emshape import EMShape, EMShapeDict
 
 	ENABLE_GUI = True
 

--- a/programs/e2helixboxer.py
+++ b/programs/e2helixboxer.py
@@ -41,10 +41,10 @@ import os
 
 try:
 	from PyQt4 import QtGui, QtCore
-	from emapplication import EMApp, get_application
-	from emimage2d import EMImage2DWidget
-	from emselector import EMSelectorDialog
-	from emshape import EMShape, EMShapeDict
+	from qtgui.emapplication import EMApp, get_application
+	from qtgui.emimage2d import EMImage2DWidget
+	from qtgui.emselector import EMSelectorDialog
+	from qtgui.emshape import EMShape, EMShapeDict
 
 	ENABLE_GUI = True
 

--- a/programs/e2help.py
+++ b/programs/e2help.py
@@ -65,7 +65,7 @@ act as a filter on the names of the algorithms."""
 		
 	if options.gui:
 		from e2projectmanager import TheHelp
-		from emapplication import EMApp
+		from qtgui.emapplication import EMApp
 		app = EMApp()
 		thehelp = TheHelp()
 		thehelp.show()

--- a/programs/e2help.py
+++ b/programs/e2help.py
@@ -65,7 +65,7 @@ act as a filter on the names of the algorithms."""
 		
 	if options.gui:
 		from e2projectmanager import TheHelp
-		from qtgui.emapplication import EMApp
+		from eman2_gui.emapplication import EMApp
 		app = EMApp()
 		thehelp = TheHelp()
 		thehelp.show()

--- a/programs/e2history.py
+++ b/programs/e2history.py
@@ -58,7 +58,7 @@ def main():
 	(options, args) = parser.parse_args()
 	
 	if options.gui:
-		from emapplication import EMApp
+		from eman2_gui.emapplication import EMApp
 		app = EMApp()
 		hist = HistoryForm(app,os.getcwd())
 		app.show()

--- a/programs/e2history.py
+++ b/programs/e2history.py
@@ -73,7 +73,7 @@ class HistoryForm:
 		'''
 		self.wd = wd
 		
-		from emform import EMFormWidget
+		from qtgui.emform import EMFormWidget
 		self.form = EMFormWidget(params=self.get_history_table())
 		self.form.setWindowTitle("EMAN2 history")
 		
@@ -85,7 +85,7 @@ class HistoryForm:
 		
 		
 	def get_history_table(self):
-		from emdatastorage import ParamDef
+		from qtgui.emdatastorage import ParamDef
 		try:
 			import EMAN2db
 			db=EMAN2db.EMAN2DB.open_db()
@@ -103,7 +103,7 @@ class HistoryForm:
 		if db == None or n == 0:
 			params.append(ParamDef(name="blurb",vartype="text",desc_short="",desc_long="",property=None,defaultunits="There appears to be no history in this directory",choices=None))
 		else:
-			from emform import EMParamTable
+			from qtgui.emform import EMParamTable
 			start = []
 			duration = []
 			prgargs = []

--- a/programs/e2history.py
+++ b/programs/e2history.py
@@ -73,7 +73,7 @@ class HistoryForm:
 		'''
 		self.wd = wd
 		
-		from qtgui.emform import EMFormWidget
+		from eman2_gui.emform import EMFormWidget
 		self.form = EMFormWidget(params=self.get_history_table())
 		self.form.setWindowTitle("EMAN2 history")
 		
@@ -85,7 +85,7 @@ class HistoryForm:
 		
 		
 	def get_history_table(self):
-		from qtgui.emdatastorage import ParamDef
+		from eman2_gui.emdatastorage import ParamDef
 		try:
 			import EMAN2db
 			db=EMAN2db.EMAN2DB.open_db()
@@ -103,7 +103,7 @@ class HistoryForm:
 		if db == None or n == 0:
 			params.append(ParamDef(name="blurb",vartype="text",desc_short="",desc_long="",property=None,defaultunits="There appears to be no history in this directory",choices=None))
 		else:
-			from qtgui.emform import EMParamTable
+			from eman2_gui.emform import EMParamTable
 			start = []
 			duration = []
 			prgargs = []

--- a/programs/e2motion.py
+++ b/programs/e2motion.py
@@ -40,9 +40,9 @@ from sys import argv
 from EMAN2 import *
 from PyQt4 import QtCore, QtGui
 from PyQt4.QtCore import Qt
-from emapplication import get_application, EMApp
-from emimage2d import EMImage2DWidget
-from emimagemx import EMImageMXWidget
+from qtgui.emapplication import get_application, EMApp
+from qtgui.emimage2d import EMImage2DWidget
+from qtgui.emimagemx import EMImageMXWidget
 from valslider import *
 import Queue
 from qtgui import embrowser

--- a/programs/e2motion.py
+++ b/programs/e2motion.py
@@ -45,7 +45,7 @@ from emimage2d import EMImage2DWidget
 from emimagemx import EMImageMXWidget
 from valslider import *
 import Queue
-import embrowser
+from qtgui import embrowser
 
 def main():
 	progname = os.path.basename(sys.argv[0])

--- a/programs/e2motion.py
+++ b/programs/e2motion.py
@@ -43,7 +43,7 @@ from PyQt4.QtCore import Qt
 from qtgui.emapplication import get_application, EMApp
 from qtgui.emimage2d import EMImage2DWidget
 from qtgui.emimagemx import EMImageMXWidget
-from valslider import *
+from qtgui.valslider import *
 import Queue
 from qtgui import embrowser
 

--- a/programs/e2motion.py
+++ b/programs/e2motion.py
@@ -40,10 +40,10 @@ from sys import argv
 from EMAN2 import *
 from PyQt4 import QtCore, QtGui
 from PyQt4.QtCore import Qt
-from qtgui.emapplication import get_application, EMApp
-from qtgui.emimage2d import EMImage2DWidget
-from qtgui.emimagemx import EMImageMXWidget
-from qtgui.valslider import *
+from eman2_gui.emapplication import get_application, EMApp
+from eman2_gui.emimage2d import EMImage2DWidget
+from eman2_gui.emimagemx import EMImageMXWidget
+from eman2_gui.valslider import *
 import Queue
 from qtgui import embrowser
 

--- a/programs/e2motion.py
+++ b/programs/e2motion.py
@@ -45,7 +45,7 @@ from eman2_gui.emimage2d import EMImage2DWidget
 from eman2_gui.emimagemx import EMImageMXWidget
 from eman2_gui.valslider import *
 import Queue
-from qtgui import embrowser
+from eman2_gui import embrowser
 
 def main():
 	progname = os.path.basename(sys.argv[0])

--- a/programs/e2pdbviewer.py
+++ b/programs/e2pdbviewer.py
@@ -31,9 +31,9 @@ from __future__ import print_function
 #
 
 from EMAN2 import *
-from emapplication import EMApp
-from emdataitem3d import EMDataItem3D
-from emscene3d import EMScene3D, EMInspector3D
+from qtgui.emapplication import EMApp
+from qtgui.emdataitem3d import EMDataItem3D
+from qtgui.emscene3d import EMScene3D, EMInspector3D
 import os
 import sys
 

--- a/programs/e2pdbviewer.py
+++ b/programs/e2pdbviewer.py
@@ -31,9 +31,9 @@ from __future__ import print_function
 #
 
 from EMAN2 import *
-from qtgui.emapplication import EMApp
-from qtgui.emdataitem3d import EMDataItem3D
-from qtgui.emscene3d import EMScene3D, EMInspector3D
+from eman2_gui.emapplication import EMApp
+from eman2_gui.emdataitem3d import EMDataItem3D
+from eman2_gui.emscene3d import EMScene3D, EMInspector3D
 import os
 import sys
 

--- a/programs/e2plotEulers.py
+++ b/programs/e2plotEulers.py
@@ -32,8 +32,8 @@ from __future__ import print_function
 #
 
 from EMAN2 import *
-from emplot2d import EMPolarPlot2DWidget,colortypes
-from emapplication import EMApp
+from qtgui.emplot2d import EMPolarPlot2DWidget,colortypes
+from qtgui.emapplication import EMApp
 import math
 
 def main():

--- a/programs/e2plotEulers.py
+++ b/programs/e2plotEulers.py
@@ -32,8 +32,8 @@ from __future__ import print_function
 #
 
 from EMAN2 import *
-from qtgui.emplot2d import EMPolarPlot2DWidget,colortypes
-from qtgui.emapplication import EMApp
+from eman2_gui.emplot2d import EMPolarPlot2DWidget,colortypes
+from eman2_gui.emapplication import EMApp
 import math
 
 def main():

--- a/programs/e2projectmanager.py
+++ b/programs/e2projectmanager.py
@@ -37,9 +37,9 @@ from PyQt4.QtCore import Qt
 from pmicons import *
 import os, json, re, glob, signal
 import subprocess
-from empmwidgets import *
+from qtgui.empmwidgets import *
 from valslider import EMQTColorWidget
-from embrowser import EMBrowserWidget
+from qtgui.embrowser import EMBrowserWidget
 
 class EMProjectManager(QtGui.QMainWindow):
 	""" The EM Project Manager is a QT application to provide a GUI for EMAN2 job managment.

--- a/programs/e2projectmanager.py
+++ b/programs/e2projectmanager.py
@@ -38,7 +38,7 @@ from qtgui.pmicons import *
 import os, json, re, glob, signal
 import subprocess
 from qtgui.empmwidgets import *
-from valslider import EMQTColorWidget
+from qtgui.valslider import EMQTColorWidget
 from qtgui.embrowser import EMBrowserWidget
 
 class EMProjectManager(QtGui.QMainWindow):

--- a/programs/e2projectmanager.py
+++ b/programs/e2projectmanager.py
@@ -2094,7 +2094,7 @@ first upgrade the project with e2projectupdate21.py. You can still use the e2dis
 GUI directly to browse the contents of old-style projects.""")
 		sys.exit(1)
 
-	from emapplication import EMApp
+	from eman2_gui.emapplication import EMApp
 	app = EMApp()
 	#app = QtGui.QApplication(sys.argv)
 	pm = EMProjectManager()

--- a/programs/e2projectmanager.py
+++ b/programs/e2projectmanager.py
@@ -34,12 +34,12 @@ from __future__ import print_function
 from EMAN2 import *
 from PyQt4 import QtCore, QtGui
 from PyQt4.QtCore import Qt
-from qtgui.pmicons import *
+from eman2_gui.pmicons import *
 import os, json, re, glob, signal
 import subprocess
-from qtgui.empmwidgets import *
-from qtgui.valslider import EMQTColorWidget
-from qtgui.embrowser import EMBrowserWidget
+from eman2_gui.empmwidgets import *
+from eman2_gui.valslider import EMQTColorWidget
+from eman2_gui.embrowser import EMBrowserWidget
 
 class EMProjectManager(QtGui.QMainWindow):
 	""" The EM Project Manager is a QT application to provide a GUI for EMAN2 job managment.

--- a/programs/e2projectmanager.py
+++ b/programs/e2projectmanager.py
@@ -34,7 +34,7 @@ from __future__ import print_function
 from EMAN2 import *
 from PyQt4 import QtCore, QtGui
 from PyQt4.QtCore import Qt
-from pmicons import *
+from qtgui.pmicons import *
 import os, json, re, glob, signal
 import subprocess
 from qtgui.empmwidgets import *

--- a/programs/e2simmxxplor.py
+++ b/programs/e2simmxxplor.py
@@ -38,13 +38,13 @@ from PyQt4 import QtGui,QtCore
 from valslider import ValSlider
 
 from e2eulerxplor import get_eulers_from
-from emimagemx import EMImageMXWidget
-from emimage2d import EMImage2DWidget
-from emplot2d import EMPlot2DWidget
+from qtgui.emimagemx import EMImageMXWidget
+from qtgui.emimage2d import EMImage2DWidget
+from qtgui.emplot2d import EMPlot2DWidget
 from EMAN2db import db_convert_path, db_open_dict, db_check_dict, db_list_dicts
-from emapplication import EMApp, get_application
-from emglobjects import EM3DGLWidget
-from emimage3dsym import EM3DSymModel,EMSymInspector, EMSymViewerWidget
+from qtgui.emapplication import EMApp, get_application
+from qtgui.emglobjects import EM3DGLWidget
+from qtgui.emimage3dsym import EM3DSymModel,EMSymInspector, EMSymViewerWidget
 from EMAN2 import *
 
 def main():

--- a/programs/e2simmxxplor.py
+++ b/programs/e2simmxxplor.py
@@ -35,16 +35,16 @@ from __future__ import print_function
 
 import os,sys
 from PyQt4 import QtGui,QtCore
-from qtgui.valslider import ValSlider
+from eman2_gui.valslider import ValSlider
 
 from e2eulerxplor import get_eulers_from
-from qtgui.emimagemx import EMImageMXWidget
-from qtgui.emimage2d import EMImage2DWidget
-from qtgui.emplot2d import EMPlot2DWidget
+from eman2_gui.emimagemx import EMImageMXWidget
+from eman2_gui.emimage2d import EMImage2DWidget
+from eman2_gui.emplot2d import EMPlot2DWidget
 from EMAN2db import db_convert_path, db_open_dict, db_check_dict, db_list_dicts
-from qtgui.emapplication import EMApp, get_application
-from qtgui.emglobjects import EM3DGLWidget
-from qtgui.emimage3dsym import EM3DSymModel,EMSymInspector, EMSymViewerWidget
+from eman2_gui.emapplication import EMApp, get_application
+from eman2_gui.emglobjects import EM3DGLWidget
+from eman2_gui.emimage3dsym import EM3DSymModel,EMSymInspector, EMSymViewerWidget
 from EMAN2 import *
 
 def main():

--- a/programs/e2simmxxplor.py
+++ b/programs/e2simmxxplor.py
@@ -35,7 +35,7 @@ from __future__ import print_function
 
 import os,sys
 from PyQt4 import QtGui,QtCore
-from valslider import ValSlider
+from qtgui.valslider import ValSlider
 
 from e2eulerxplor import get_eulers_from
 from qtgui.emimagemx import EMImageMXWidget

--- a/programs/e2spt_boxer.py
+++ b/programs/e2spt_boxer.py
@@ -38,13 +38,13 @@ import numpy as np
 import weakref
 from PyQt4 import QtCore, QtGui
 from PyQt4.QtCore import Qt
-from emapplication import get_application, EMApp
-from emimage2d import EMImage2DWidget
-from emimagemx import EMImageMXWidget
-from emimage3d import EMImage3DWidget
-from emscene3d import EMScene3D
-from emdataitem3d import EMDataItem3D, EMIsosurface
-from emshape import EMShape
+from qtgui.emapplication import get_application, EMApp
+from qtgui.emimage2d import EMImage2DWidget
+from qtgui.emimagemx import EMImageMXWidget
+from qtgui.emimage3d import EMImage3DWidget
+from qtgui.emscene3d import EMScene3D
+from qtgui.emdataitem3d import EMDataItem3D, EMIsosurface
+from qtgui.emshape import EMShape
 from valslider import ValSlider, ValBox
 
 	

--- a/programs/e2spt_boxer.py
+++ b/programs/e2spt_boxer.py
@@ -45,7 +45,7 @@ from qtgui.emimage3d import EMImage3DWidget
 from qtgui.emscene3d import EMScene3D
 from qtgui.emdataitem3d import EMDataItem3D, EMIsosurface
 from qtgui.emshape import EMShape
-from valslider import ValSlider, ValBox
+from qtgui.valslider import ValSlider, ValBox
 
 	
 def run(cmd):

--- a/programs/e2spt_boxer.py
+++ b/programs/e2spt_boxer.py
@@ -38,14 +38,14 @@ import numpy as np
 import weakref
 from PyQt4 import QtCore, QtGui
 from PyQt4.QtCore import Qt
-from qtgui.emapplication import get_application, EMApp
-from qtgui.emimage2d import EMImage2DWidget
-from qtgui.emimagemx import EMImageMXWidget
-from qtgui.emimage3d import EMImage3DWidget
-from qtgui.emscene3d import EMScene3D
-from qtgui.emdataitem3d import EMDataItem3D, EMIsosurface
-from qtgui.emshape import EMShape
-from qtgui.valslider import ValSlider, ValBox
+from eman2_gui.emapplication import get_application, EMApp
+from eman2_gui.emimage2d import EMImage2DWidget
+from eman2_gui.emimagemx import EMImageMXWidget
+from eman2_gui.emimage3d import EMImage3DWidget
+from eman2_gui.emscene3d import EMScene3D
+from eman2_gui.emdataitem3d import EMDataItem3D, EMIsosurface
+from eman2_gui.emshape import EMShape
+from eman2_gui.valslider import ValSlider, ValBox
 
 	
 def run(cmd):

--- a/programs/e2spt_wedge.py
+++ b/programs/e2spt_wedge.py
@@ -34,8 +34,8 @@ from EMAN2 import *
 from PyQt4 import QtCore, QtGui, QtOpenGL
 from PyQt4.QtCore import Qt
 from eman2_gui.emapplication import EMApp
-from qtgui import emscene3d
-from qtgui import emdataitem3d 
+from eman2_gui import emscene3d
+from eman2_gui import emdataitem3d 
 
 def main():
 	progname = os.path.basename(sys.argv[0])

--- a/programs/e2spt_wedge.py
+++ b/programs/e2spt_wedge.py
@@ -34,8 +34,8 @@ from EMAN2 import *
 from PyQt4 import QtCore, QtGui, QtOpenGL
 from PyQt4.QtCore import Qt
 from emapplication import EMApp
-import emscene3d
-import emdataitem3d 
+from qtgui import emscene3d
+from qtgui import emdataitem3d 
 
 def main():
 	progname = os.path.basename(sys.argv[0])

--- a/programs/e2spt_wedge.py
+++ b/programs/e2spt_wedge.py
@@ -33,7 +33,7 @@ from __future__ import print_function
 from EMAN2 import *
 from PyQt4 import QtCore, QtGui, QtOpenGL
 from PyQt4.QtCore import Qt
-from emapplication import EMApp
+from qtgui.emapplication import EMApp
 from qtgui import emscene3d
 from qtgui import emdataitem3d 
 

--- a/programs/e2spt_wedge.py
+++ b/programs/e2spt_wedge.py
@@ -33,7 +33,7 @@ from __future__ import print_function
 from EMAN2 import *
 from PyQt4 import QtCore, QtGui, QtOpenGL
 from PyQt4.QtCore import Qt
-from qtgui.emapplication import EMApp
+from eman2_gui.emapplication import EMApp
 from qtgui import emscene3d
 from qtgui import emdataitem3d 
 

--- a/programs/e2tiltvalidate.py
+++ b/programs/e2tiltvalidate.py
@@ -437,9 +437,9 @@ def run(command):
 try:
 	from PyQt4 import QtCore, QtGui, QtOpenGL
 	from PyQt4.QtCore import Qt
-	from emshape import *
+	from qtgui.emshape import *
 	from valslider import ValSlider
-	from emplot2d import EMPolarPlot2DWidget
+	from qtgui.emplot2d import EMPolarPlot2DWidget
 except:
 	class dummy:
 		pass
@@ -451,8 +451,8 @@ except:
 	QtGui.QWidget=QWidget
 
 def display_validation_plots(path, radcut, planethres, plotdatalabels=False, color='#00ff00', plotzaxiscolor=False):
-	from emimage2d import EMImage2DWidget
-	from emapplication import EMApp
+	from qtgui.emimage2d import EMImage2DWidget
+	from qtgui.emapplication import EMApp
 	r = []
 	theta = []
 	datap = []

--- a/programs/e2tiltvalidate.py
+++ b/programs/e2tiltvalidate.py
@@ -437,9 +437,9 @@ def run(command):
 try:
 	from PyQt4 import QtCore, QtGui, QtOpenGL
 	from PyQt4.QtCore import Qt
-	from qtgui.emshape import *
-	from qtgui.valslider import ValSlider
-	from qtgui.emplot2d import EMPolarPlot2DWidget
+	from eman2_gui.emshape import *
+	from eman2_gui.valslider import ValSlider
+	from eman2_gui.emplot2d import EMPolarPlot2DWidget
 except:
 	class dummy:
 		pass
@@ -451,8 +451,8 @@ except:
 	QtGui.QWidget=QWidget
 
 def display_validation_plots(path, radcut, planethres, plotdatalabels=False, color='#00ff00', plotzaxiscolor=False):
-	from qtgui.emimage2d import EMImage2DWidget
-	from qtgui.emapplication import EMApp
+	from eman2_gui.emimage2d import EMImage2DWidget
+	from eman2_gui.emapplication import EMApp
 	r = []
 	theta = []
 	datap = []

--- a/programs/e2tiltvalidate.py
+++ b/programs/e2tiltvalidate.py
@@ -438,7 +438,7 @@ try:
 	from PyQt4 import QtCore, QtGui, QtOpenGL
 	from PyQt4.QtCore import Qt
 	from qtgui.emshape import *
-	from valslider import ValSlider
+	from qtgui.valslider import ValSlider
 	from qtgui.emplot2d import EMPolarPlot2DWidget
 except:
 	class dummy:

--- a/programs/e2tomoresolution.py
+++ b/programs/e2tomoresolution.py
@@ -34,8 +34,8 @@ from __future__ import print_function
 
 
 from EMAN2 import *
-from emplot2d import EMPlot2DWidget
-from emapplication import EMApp
+from qtgui.emplot2d import EMPlot2DWidget
+from qtgui.emapplication import EMApp
 
 def main():
 	progname = os.path.basename(sys.argv[0])

--- a/programs/e2tomoresolution.py
+++ b/programs/e2tomoresolution.py
@@ -34,8 +34,8 @@ from __future__ import print_function
 
 
 from EMAN2 import *
-from qtgui.emplot2d import EMPlot2DWidget
-from qtgui.emapplication import EMApp
+from eman2_gui.emplot2d import EMPlot2DWidget
+from eman2_gui.emapplication import EMApp
 
 def main():
 	progname = os.path.basename(sys.argv[0])

--- a/programs/e2tomoseg_buildtrainset.py
+++ b/programs/e2tomoseg_buildtrainset.py
@@ -4,9 +4,9 @@ from __future__ import print_function
 from EMAN2 import *
 import numpy as np
 import random
-from qtgui.emapplication import EMApp
-from qtgui.emimage import EMImageWidget
-from qtgui.emboxerbase import *
+from eman2_gui.emapplication import EMApp
+from eman2_gui.emimage import EMImageWidget
+from eman2_gui.emboxerbase import *
 import shutil
 
 

--- a/programs/e2tomoseg_buildtrainset.py
+++ b/programs/e2tomoseg_buildtrainset.py
@@ -4,9 +4,9 @@ from __future__ import print_function
 from EMAN2 import *
 import numpy as np
 import random
-from emapplication import EMApp
-from emimage import EMImageWidget
-from emboxerbase import *
+from qtgui.emapplication import EMApp
+from qtgui.emimage import EMImageWidget
+from qtgui.emboxerbase import *
 import shutil
 
 

--- a/programs/eman2.py
+++ b/programs/eman2.py
@@ -51,7 +51,7 @@ If you are just getting started with EMAN2, here are some tips:
 
 from EMAN2 import *
 from EMAN2_meta import FULLVERSIONSTRING
-from qtgui.emapplication import EMApp
+from eman2_gui.emapplication import EMApp
 import os, json, re, glob, signal
 import subprocess
 

--- a/programs/eman2.py
+++ b/programs/eman2.py
@@ -51,7 +51,7 @@ If you are just getting started with EMAN2, here are some tips:
 
 from EMAN2 import *
 from EMAN2_meta import FULLVERSIONSTRING
-from emapplication import EMApp
+from qtgui.emapplication import EMApp
 import os, json, re, glob, signal
 import subprocess
 

--- a/pyemtbx/boxertools.py
+++ b/pyemtbx/boxertools.py
@@ -2276,7 +2276,7 @@ class Boxable:
 		
 	def process_finished(self,int):
 		try:
-			from emimage import EMImage
+			from qtgui.emimage import EMImage
 		except:
 			print("Cannot import EMAN image GUI objects (emimage,etc.)")
 			sys.exit(1)

--- a/pyemtbx/boxertools.py
+++ b/pyemtbx/boxertools.py
@@ -2276,7 +2276,7 @@ class Boxable:
 		
 	def process_finished(self,int):
 		try:
-			from qtgui.emimage import EMImage
+			from eman2_gui.emimage import EMImage
 		except:
 			print("Cannot import EMAN image GUI objects (emimage,etc.)")
 			sys.exit(1)

--- a/rt/demo/scene3d_test.py
+++ b/rt/demo/scene3d_test.py
@@ -2,8 +2,8 @@
 from __future__ import print_function
 
 from PyQt4 import QtCore, QtGui, QtOpenGL
-from emscene3d import EMScene3D, EMInspector3D, EMInspectorControlShape
-from emshapeitem3d import *
+from qtgui.emscene3d import EMScene3D, EMInspector3D, EMInspectorControlShape
+from qtgui.emshapeitem3d import *
 
 from EMAN2 import *
 

--- a/rt/demo/scene3d_test.py
+++ b/rt/demo/scene3d_test.py
@@ -2,8 +2,8 @@
 from __future__ import print_function
 
 from PyQt4 import QtCore, QtGui, QtOpenGL
-from qtgui.emscene3d import EMScene3D, EMInspector3D, EMInspectorControlShape
-from qtgui.emshapeitem3d import *
+from eman2_gui.emscene3d import EMScene3D, EMInspector3D, EMInspectorControlShape
+from eman2_gui.emshapeitem3d import *
 
 from EMAN2 import *
 

--- a/sparx/bin/sx_real.py
+++ b/sparx/bin/sx_real.py
@@ -45,14 +45,14 @@ try:
 	if get_platform()=="Linux" and os.getenv("DISPLAY")==None: raise Exception
 
 	from PyQt4 import QtCore, QtGui, QtOpenGL
-	from qtgui.emapplication import EMApp
+	from eman2_gui.emapplication import EMApp
 	import IPython.lib.inputhook
 
 
 	app=EMApp()
 	IPython.lib.inputhook.enable_qt4(app)
 
-	from qtgui.emimage import image_update
+	from eman2_gui.emimage import image_update
 
 	def ipy_on_timer():
 		image_update()

--- a/sparx/bin/sx_real.py
+++ b/sparx/bin/sx_real.py
@@ -45,14 +45,14 @@ try:
 	if get_platform()=="Linux" and os.getenv("DISPLAY")==None: raise Exception
 
 	from PyQt4 import QtCore, QtGui, QtOpenGL
-	from emapplication import EMApp
+	from qtgui.emapplication import EMApp
 	import IPython.lib.inputhook
 
 
 	app=EMApp()
 	IPython.lib.inputhook.enable_qt4(app)
 
-	from emimage import image_update
+	from qtgui.emimage import image_update
 
 	def ipy_on_timer():
 		image_update()

--- a/sparx/bin/sxctf.py
+++ b/sparx/bin/sxctf.py
@@ -47,7 +47,7 @@ from numpy import *
 import os
 import sys
 import weakref
-from emapplication import EMApp
+from qtgui.emapplication import EMApp
 
 from Simplex import Simplex
 
@@ -846,12 +846,12 @@ class GUIctf(QtGui.QWidget):
 		'data' is a list of (filename,ctf,im_1d,bg_1d,im_2d,bg_2d)
 		"""
 		try:
-			from emimage2d import EMImage2DWidget
+			from qtgui.emimage2d import EMImage2DWidget
 		except:
 			print("Cannot import EMAN image GUI objects (EMImage2DWidget)")
 			sys.exit(1)
 		try: 
-			from emplot2d import EMPlot2DWidget
+			from qtgui.emplot2d import EMPlot2DWidget
 		except:
 			print("Cannot import EMAN plot GUI objects (is matplotlib installed?)")
 			sys.exit(1)
@@ -1001,7 +1001,7 @@ class GUIctf(QtGui.QWidget):
 #	def get_output_params(self):
 	
 	def on_output(self):
-		from emsprworkflow import E2CTFOutputTaskGeneral
+		from qtgui.emsprworkflow import E2CTFOutputTaskGeneral
 		self.form = E2CTFOutputTaskGeneral()
 		self.form.run_form()
 	

--- a/sparx/bin/sxctf.py
+++ b/sparx/bin/sxctf.py
@@ -47,7 +47,7 @@ from numpy import *
 import os
 import sys
 import weakref
-from qtgui.emapplication import EMApp
+from eman2_gui.emapplication import EMApp
 
 from Simplex import Simplex
 
@@ -828,7 +828,7 @@ def ctf_env_points(im_1d,bg_1d,ctf) :
 try:
 	from PyQt4 import QtCore, QtGui, QtOpenGL
 	from PyQt4.QtCore import Qt
-	from qtgui.valslider import ValSlider
+	from eman2_gui.valslider import ValSlider
 except:
 	print("Warning: PyQt4 must be installed to use the --gui option")
 	class dummy:
@@ -846,12 +846,12 @@ class GUIctf(QtGui.QWidget):
 		'data' is a list of (filename,ctf,im_1d,bg_1d,im_2d,bg_2d)
 		"""
 		try:
-			from qtgui.emimage2d import EMImage2DWidget
+			from eman2_gui.emimage2d import EMImage2DWidget
 		except:
 			print("Cannot import EMAN image GUI objects (EMImage2DWidget)")
 			sys.exit(1)
 		try: 
-			from qtgui.emplot2d import EMPlot2DWidget
+			from eman2_gui.emplot2d import EMPlot2DWidget
 		except:
 			print("Cannot import EMAN plot GUI objects (is matplotlib installed?)")
 			sys.exit(1)
@@ -1001,7 +1001,7 @@ class GUIctf(QtGui.QWidget):
 #	def get_output_params(self):
 	
 	def on_output(self):
-		from qtgui.emsprworkflow import E2CTFOutputTaskGeneral
+		from eman2_gui.emsprworkflow import E2CTFOutputTaskGeneral
 		self.form = E2CTFOutputTaskGeneral()
 		self.form.run_form()
 	

--- a/sparx/bin/sxctf.py
+++ b/sparx/bin/sxctf.py
@@ -828,7 +828,7 @@ def ctf_env_points(im_1d,bg_1d,ctf) :
 try:
 	from PyQt4 import QtCore, QtGui, QtOpenGL
 	from PyQt4.QtCore import Qt
-	from valslider import ValSlider
+	from qtgui.valslider import ValSlider
 except:
 	print("Warning: PyQt4 must be installed to use the --gui option")
 	class dummy:

--- a/sparx/bin/sxgui_cter.py
+++ b/sparx/bin/sxgui_cter.py
@@ -44,7 +44,7 @@ try:
 	from PyQt4.QtCore import Qt
 	from PyQt4.QtCore import QTimer
 	from qtgui.emshape import *
-	from valslider import *
+	from qtgui.valslider import *
 	from qtgui.emplot2d import EMPlot2DWidget
 except:
 	print("Warning: PyQt4 must be installed")

--- a/sparx/bin/sxgui_cter.py
+++ b/sparx/bin/sxgui_cter.py
@@ -43,9 +43,9 @@ try:
 	from PyQt4 import QtCore, QtGui, QtOpenGL
 	from PyQt4.QtCore import Qt
 	from PyQt4.QtCore import QTimer
-	from qtgui.emshape import *
-	from qtgui.valslider import *
-	from qtgui.emplot2d import EMPlot2DWidget
+	from eman2_gui.emshape import *
+	from eman2_gui.valslider import *
+	from eman2_gui.emplot2d import EMPlot2DWidget
 except:
 	print("Warning: PyQt4 must be installed")
 	sys.exit(1)
@@ -67,7 +67,7 @@ def main():
 		print("see usage " + usage)
 		sys.exit()
 	
-	from qtgui.emapplication import EMApp
+	from eman2_gui.emapplication import EMApp
 	app=EMApp()
 	
 	cter_ctf_file = None
@@ -146,7 +146,7 @@ class SXGuiCter(QtGui.QWidget):
 		'parms' is [box size,ctf,box coord,set of excluded boxnums,quality,oversampling]
 		"""
 		try:
-			from qtgui.emimage2d import EMImage2DWidget
+			from eman2_gui.emimage2d import EMImage2DWidget
 		except:
 			print("Cannot import EMAN image GUI objects (EMImage2DWidget)")
 			sys.exit(1)

--- a/sparx/bin/sxgui_cter.py
+++ b/sparx/bin/sxgui_cter.py
@@ -43,9 +43,9 @@ try:
 	from PyQt4 import QtCore, QtGui, QtOpenGL
 	from PyQt4.QtCore import Qt
 	from PyQt4.QtCore import QTimer
-	from emshape import *
+	from qtgui.emshape import *
 	from valslider import *
-	from emplot2d import EMPlot2DWidget
+	from qtgui.emplot2d import EMPlot2DWidget
 except:
 	print("Warning: PyQt4 must be installed")
 	sys.exit(1)
@@ -67,7 +67,7 @@ def main():
 		print("see usage " + usage)
 		sys.exit()
 	
-	from emapplication import EMApp
+	from qtgui.emapplication import EMApp
 	app=EMApp()
 	
 	cter_ctf_file = None
@@ -146,7 +146,7 @@ class SXGuiCter(QtGui.QWidget):
 		'parms' is [box size,ctf,box coord,set of excluded boxnums,quality,oversampling]
 		"""
 		try:
-			from emimage2d import EMImage2DWidget
+			from qtgui.emimage2d import EMImage2DWidget
 		except:
 			print("Cannot import EMAN image GUI objects (EMImage2DWidget)")
 			sys.exit(1)

--- a/sparx/bin/sxhelixboxer.py
+++ b/sparx/bin/sxhelixboxer.py
@@ -40,10 +40,10 @@ import os
 
 try:
 	from PyQt4 import QtGui, QtCore
-	from emapplication import EMApp, get_application
-	from emimage2d import EMImage2DWidget
-	from emselector import EMSelectorDialog
-	from emshape import EMShape, EMShapeDict
+	from qtgui.emapplication import EMApp, get_application
+	from qtgui.emimage2d import EMImage2DWidget
+	from qtgui.emselector import EMSelectorDialog
+	from qtgui.emshape import EMShape, EMShapeDict
 	
 	ENABLE_GUI = True
 	

--- a/sparx/bin/sxhelixboxer.py
+++ b/sparx/bin/sxhelixboxer.py
@@ -40,10 +40,10 @@ import os
 
 try:
 	from PyQt4 import QtGui, QtCore
-	from qtgui.emapplication import EMApp, get_application
-	from qtgui.emimage2d import EMImage2DWidget
-	from qtgui.emselector import EMSelectorDialog
-	from qtgui.emshape import EMShape, EMShapeDict
+	from eman2_gui.emapplication import EMApp, get_application
+	from eman2_gui.emimage2d import EMImage2DWidget
+	from eman2_gui.emselector import EMSelectorDialog
+	from eman2_gui.emshape import EMShape, EMShapeDict
 	
 	ENABLE_GUI = True
 	


### PR DESCRIPTION
Installs the contents of `libpyEM/qtgui` as a package. Primary motivation is to be able to include qtgui files in code coverage analysis easily.