### PR TITLE
Fix argument passing to `basename` in tests, due to non-portable option

### DIFF
--- a/tests/run_prog_tests.sh
+++ b/tests/run_prog_tests.sh
@@ -5,7 +5,7 @@
 set -e
 
 # Gather programs from CONDA_PREFIX
-progs=$(find "${CONDA_PREFIX}"/bin -name 'e2*.py' | xargs basename -a)
+progs=$(find "${CONDA_PREFIX}"/bin -name 'e2*.py' | xargs -n 1 basename)
 # Remove programs listed in "programs_no_test.txt"
 MYDIR="$(cd "$(dirname "$0")"; pwd -P)"
 progs_exclude=$(cat "${MYDIR}"/programs_no_test.txt | awk '{print $1}')


### PR DESCRIPTION
Should fix binary builds on Linux.