### PR TITLE
Prevent upgrading to conda-build 3 on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,6 @@ install:
     - call setup_x64
 
     - conda install --quiet --yes conda-build=2
-    - conda update --yes --quiet conda -c defaults
 
     - conda info
     - conda config --get


### PR DESCRIPTION
Conda-build 3 seems to exit with code 0 on Appveyor, even if the build fails. First occurrence observed here, e50fcedb76515883c74095726352114a1beb5bb1. As a result the broken builds pass. This PR makes sure to use conda-build 2, after which master will be broken for Windows due to e50fcedb76515883c74095726352114a1beb5bb1.