### PR TITLE
Add nose explicitly to dependencies

### DIFF
--- a/ci_support/setup_conda.sh
+++ b/ci_support/setup_conda.sh
@@ -12,4 +12,4 @@ bash $MINICONDA_FILE -b
 source ${HOME}/miniconda2/bin/activate root
 conda config --set show_channel_urls true
 
-conda install cmake -c anaconda --yes --quiet
+conda install cmake -c defaults --yes --quiet

--- a/ci_support/setup_conda.sh
+++ b/ci_support/setup_conda.sh
@@ -12,4 +12,4 @@ bash $MINICONDA_FILE -b
 source ${HOME}/miniconda2/bin/activate root
 conda config --set show_channel_urls true
 
-conda install cmake -c defaults --yes --quiet
+conda install cmake nose -c defaults --yes --quiet

--- a/recipes/eman/meta.yaml
+++ b/recipes/eman/meta.yaml
@@ -29,6 +29,7 @@ requirements:
             "scikit-learn",
             "bsddb",       # [not win]
             "pydusa",      # [not win]
+            "nose",
     ] %}
     
     build:


### PR DESCRIPTION
`nose` used to be pulled in by automatically, but that is not the case on TravisCI anymore. This adds the dependency explicitly.