### PR TITLE
Pin openmpi to 2.0.2 in constructor

### DIFF
--- a/recipes/eman/meta.yaml
+++ b/recipes/eman/meta.yaml
@@ -29,8 +29,9 @@ requirements:
             "pyopengl 3.1.0",
             "theano 0.9.*",
             "scikit-learn 0.19.*",
-            "bsddb",       # [not win]
-            "pydusa",      # [not win]
+            "bsddb",          # [not win]
+            "openmpi 2.0.2",  # [not win]
+            "pydusa",         # [not win]
             "nose",
     ] %}
     

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -7,4 +7,7 @@ e2speedtest.py
 
 python "${SRC_DIR}/tests/test_EMAN2DIR.py"
 
+if [ $(whoami) != "root" ];then
+    mpirun -n 4 $(which python) ${PREFIX}/examples/mpi_test.py
+fi
 bash "${SRC_DIR}/tests/run_prog_tests.sh"


### PR DESCRIPTION
- Pins openmpi to v2.0.2 which is available on cryoem channel and pulled in by pydusa recipe.
- Channel order in [construct.yaml](https://github.com/cryoem/build-scripts/blob/jenkins-release/constructor/construct.yaml) has been updated so openmpi is pulled from cryoem channel.