### PR TITLE
Smaller binaries

### DIFF
--- a/ci_support/cluster_message.sh
+++ b/ci_support/cluster_message.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 
-cat <<EOF 
+source ${PREFIX}/bin/activate
+
+conda info -a
+conda list
+
+if [ "$(uname -s)" == "Linux" ];then
+    conda install "cudatoolkit=8.*" "cudnn 7.*" -y
+fi
+
+cat <<EOF
 
 INSTALLATION IS NOW COMPLETE
 

--- a/ci_support/construct.yaml
+++ b/ci_support/construct.yaml
@@ -24,6 +24,10 @@ specs:
   - console_shortcut  # [win]
   - menuinst          # [win]
 
+exclude:
+  - cudatoolkit     # [linux]
+  - cudnn           # [linux]
+
 welcome_image: images/EMAN2Icon.png    # [win]
 icon_image:    images/eman.ico         # [win]
 post_install:  cluster_message.sh      # [unix]

--- a/recipes/eman/meta.yaml
+++ b/recipes/eman/meta.yaml
@@ -18,7 +18,7 @@ requirements:
             "gsl",
             "hdf5 1.8.18",
             "jpeg",
-            "libtiff 4.0.9",            # [not win]
+            "libtiff 4.0.9",             # [not win]
             "libtiff 4.0.9 hafacce9_0",  # [win]
             "libpng 1.6.34",
             "zlib",
@@ -27,9 +27,9 @@ requirements:
             "scipy 1.*",
             "ipython",
             "tensorflow-gpu 1.5.*",  # [linux]
-            "cudatoolkit 8.*",  # [linux]
-            "cudnn 7.*",  # [linux]
-            "tensorflow 1.3.*",  # [osx]
+            "cudatoolkit 8.*",       # [linux]
+            "cudnn 7.*",             # [linux]
+            "tensorflow 1.3.*",      # [osx]
             "pyqt 4.11.*",
             "qt >=4.8.6",
             "pyopengl 3.1.0",

--- a/recipes/eman/meta.yaml
+++ b/recipes/eman/meta.yaml
@@ -30,7 +30,6 @@ requirements:
             "cudatoolkit 8.*",  # [linux]
             "cudnn 7.*",  # [linux]
             "tensorflow 1.3.*",  # [osx]
-            "funcsigs",  # [linux]
             "pyqt 4.11.*",
             "qt >=4.8.6",
             "pyopengl 3.1.0",


### PR DESCRIPTION
This excludes large packages, `cudatoolkit` and `cudnn`, from being bundled into the binary installers. With these packages the resulting binary for Linux are 1.2G. Instead of being bundled, these packages will be installed at post-install stage of binary installations.

This PR is a quick solution to the large binaries being uploaded as continuous builds at the moment. Soon, the same strategy will be applied to all dependencies and eman2 itself, so that the distributed binary will be minimal in size and all packages, but conda and conda dependencies, currently bundled, will be conda-installed as the final stage of the binary installation.