### PR TITLE
Binary build improvements

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,11 +50,20 @@ def deployPackage() {
                                'Centos7': 'centos7',
                                'MacOSX' : 'mac',
                               ]
+    if(GIT_BRANCH_SHORT == "master") {
+        upload_dir = 'continuous_build'
+        upload_ext = 'unstable'
+    }
+    if(GIT_BRANCH_SHORT != "master") {
+        upload_dir = 'experimental'
+        upload_ext = 'experimental'
+    }
+    
     if(isBinaryBuild()) {
         if(SLAVE_OS != 'win')
-            sh "rsync -avzh --stats ${INSTALLERS_DIR}/eman2.${SLAVE_OS}.sh ${DEPLOY_DEST}/continuous_build/eman2." + installer_base_name[JOB_NAME] + ".unstable.sh"
+            sh "rsync -avzh --stats ${INSTALLERS_DIR}/eman2.${SLAVE_OS}.sh ${DEPLOY_DEST}/" + upload_dir + "/eman2." + installer_base_name[JOB_NAME] + "." + upload_ext + ".sh"
         else
-            bat 'ci_support\\rsync_wrapper.bat'
+            bat 'ci_support\\rsync_wrapper.bat ' + upload_dir + ' ' + upload_ext
     }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,12 +35,7 @@ def isReleaseBuild() {
 }
 
 def isBinaryBuild() {
-    def buildOS = ['linux': CI_BUILD_LINUX,
-                   'mac':   CI_BUILD_MAC,
-                   'win':   CI_BUILD_WIN
-                  ]
-    
-    return (CI_BUILD == "1" || buildOS[SLAVE_OS] == "1")
+    return CI_BUILD == "1"
 }
 
 def testPackage() {
@@ -94,9 +89,6 @@ pipeline {
     INSTALLERS_DIR = '${HOME_DIR}/workspace/${JOB_NAME}-installers'
 
     CI_BUILD       = sh(script: "! git log -1 | grep '.*\\[ci build\\].*'",       returnStatus: true)
-    CI_BUILD_WIN   = sh(script: "! git log -1 | grep '.*\\[ci build win\\].*'",   returnStatus: true)
-    CI_BUILD_LINUX = sh(script: "! git log -1 | grep '.*\\[ci build linux\\].*'", returnStatus: true)
-    CI_BUILD_MAC   = sh(script: "! git log -1 | grep '.*\\[ci build mac\\].*'",   returnStatus: true)
   }
   
   stages {

--- a/ci_support/build_no_recipe.sh
+++ b/ci_support/build_no_recipe.sh
@@ -16,6 +16,12 @@ rm -vf ${CONDA_PREFIX}/bin/e2*.py
 conda info -a
 conda list
 
+if [ -z "$JENKINS_HOME" ];then
+    CPU_COUNT=4
+else
+    CPU_COUNT=2
+fi
+
 build_dir="../build_eman"
 src_dir=${PWD}
 
@@ -24,7 +30,7 @@ mkdir -p $build_dir
 cd $build_dir
 
 cmake ${src_dir}
-make -j4
+make -j${CPU_COUNT}
 make install
 
 # Run tests

--- a/ci_support/build_recipe.sh
+++ b/ci_support/build_recipe.sh
@@ -17,5 +17,6 @@ fi
 conda info -a
 conda list
 conda render recipes/eman
+conda build purge-all
 
 conda build recipes/eman -c cryoem -c defaults -c conda-forge --quiet

--- a/ci_support/construct.yaml
+++ b/ci_support/construct.yaml
@@ -18,6 +18,7 @@ ignore_duplicate_files: True
 
 specs:
   - eman2 2.21
+  - defaults::funcsigs  # [linux]
   - conda
   - conda-build
   - pip

--- a/ci_support/rsync_wrapper.bat
+++ b/ci_support/rsync_wrapper.bat
@@ -1,3 +1,3 @@
 set "BASH_EXE=C:\Program Files\Git\bin\bash.exe"
 
-"%BASH_EXE%" -c "rsync -avzh --stats /c/Users/EMAN/workspace/win-installers/eman2.win.exe %DEPLOY_DEST%/continuous_build/eman2.win.unstable.exe"
+"%BASH_EXE%" -c "rsync -avzh --stats /c/Users/EMAN/workspace/win-installers/eman2.win.exe %DEPLOY_DEST%/%1/eman2.win.%2.exe"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -7,6 +7,10 @@ MYDIR="$(cd "$(dirname "$0")"; pwd -P)"
 e2version.py
 e2speedtest.py
 
+if [ ${CONDA_BUILD:-0} -ne 1 ];then
+    bash "${MYDIR}/test_git_hash.sh"
+fi
+
 python "${MYDIR}/test_EMAN2DIR.py"
 
 if [ $(whoami) != "root" ];then

--- a/tests/test_git_hash.sh
+++ b/tests/test_git_hash.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -xe
+
+GITHASH=$(python -c "from EMAN2_meta import GITHASH; print(GITHASH)")
+
+if [ ! -z "$JENKINS_HOME" ];then
+    THIS_COMMIT_HASH="$GIT_COMMIT_SHORT"
+elif [ ${CIRCLECI} ];then
+    THIS_COMMIT_HASH="$CIRCLE_SHA1"
+elif [ ${TRAVIS} ];then
+    THIS_COMMIT_HASH="$TRAVIS_COMMIT"
+else
+    THIS_COMMIT_HASH="       "
+fi
+
+GITHASH=${GITHASH:0:7}
+THIS_COMMIT_HASH=${THIS_COMMIT_HASH:0:7}
+
+test "${GITHASH}" == "${THIS_COMMIT_HASH}"


### PR DESCRIPTION
- Adds a test for the git commit hash of the resulting binary.
- Removes os-specific build triggers to reduce code complexity. The only valid trigger is the message `[ci build]` in the commit message.
- When a binary build is triggered with `[ci build]`, if the branch is `master`, the binary is uploaded as "continuous build", https://cryoem.bcm.edu/downloads/view_eman2_version/25, else as "experimental build", https://cryoem.bcm.edu/downloads/view_eman2_version/26. This gives opportunity to test binaries without breaking "continuous builds".