### PR TITLE
Add unit tests back to CI

### DIFF
--- a/ci_support/build_no_recipe.sh
+++ b/ci_support/build_no_recipe.sh
@@ -49,4 +49,5 @@ make -j${CPU_COUNT}
 make install
 
 # Run tests
-bash ${src_dir}/tests/run_tests.sh
+cd "${src_dir}"
+bash tests/run_tests.sh

--- a/ci_support/build_no_recipe.sh
+++ b/ci_support/build_no_recipe.sh
@@ -33,6 +33,10 @@ else
     CPU_COUNT=2
 fi
 
+if [ "$(uname -s)" == "Darwin" ];then
+    export EMAN_TEST_SKIP=1
+fi
+
 build_dir="../build_eman"
 src_dir=${PWD}
 

--- a/recipes/eman/meta.yaml
+++ b/recipes/eman/meta.yaml
@@ -42,10 +42,12 @@ test:
     - openmpi              # [not win]
     - eman-deps=11.2
     - future
+    - nose
   
   source_files:
     - examples/mpi_test.py
     - tests/
+    - rt/pyem/
 
   commands:
     - bash tests/run_tests.sh                                # [not win]

--- a/recipes/eman/meta.yaml
+++ b/recipes/eman/meta.yaml
@@ -45,11 +45,7 @@ test:
   
   source_files:
     - examples/mpi_test.py
-    - tests/run_prog_tests.sh
-    - tests/programs_no_test.txt
-    - tests/test_EMAN2DIR.py
-    - tests/run_tests.sh
-    - tests/run_tests.bat
+    - tests/
 
   commands:
     - bash tests/run_tests.sh                                # [not win]

--- a/tests/run_tests.bat
+++ b/tests/run_tests.bat
@@ -4,3 +4,12 @@ e2speedtest.py
 
 :: 2. Existence tests for data files like images, font files, JSON
 python tests\test_EMAN2DIR.py
+
+:: 3. Unit tests
+nosetests -vv --exe -m "^test_*" ^
+                    -e "^test_image_" ^
+                    -e "test_main" ^
+                    -e "test_result" ^
+                    -e "test_boxing" ^
+                    -a \!broken ^
+                    %SRC_DIR%\rt\pyem

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -16,10 +16,19 @@ fi
 # 3. Existence tests for data files like images, font files, JSON
 python "${MYDIR}/test_EMAN2DIR.py"
 
-# 4. Test openmpi
+# 4. Unit tests
+nosetests -vv --exe -m "^test_*" \
+                    -e "^test_image_" \
+                    -e "test_main" \
+                    -e "test_result" \
+                    -e "test_boxing" \
+                    -a \!broken \
+                    rt/pyem/
+
+# 5. Test openmpi
 if [ $(whoami) != "root" ] && [ "$(uname -s)" != "Darwin" ];then
     mpirun -n 4 $(which python) ${MYDIR}/../examples/mpi_test.py
 fi
 
-# 5. Run e2*.py -h
+# 6. Run e2*.py -h
 bash "${MYDIR}/run_prog_tests.sh"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -17,7 +17,7 @@ fi
 python "${MYDIR}/test_EMAN2DIR.py"
 
 # 4. Test openmpi
-if [ $(whoami) != "root" ] && [ -z ${TRAVIS} ];then
+if [ $(whoami) != "root" ] && [ "$(uname -s)" != "Darwin" ];then
     mpirun -n 4 $(which python) ${MYDIR}/../examples/mpi_test.py
 fi
 


### PR DESCRIPTION
This adds the unit tests that used to be run via `make test-verbose`.

1. The tests expose a couple bugs. One is related to division in Boost bindings. The special function name for division is `__truediv__` instead of `__div__`. Will be addressed in a follow-up PR. 
1. Another failing test seems to be related to NumPy.
```
test numpy2em for float64 ........................ ... FAIL
```
```
======================================================================
FAIL: test numpy2em for float64 ........................
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/circleci/project/rt/pyem/test_typeconverter.py", line 330, in test_numpy2em2
    self.assertAlmostEqual(diff, 0, 3)
AssertionError: 1.664325630180242 != 0 within 3 places

```
cc: @jamesmbell 