### PR TITLE
Fix bild plot symmetry

### DIFF
--- a/sparx/libpy/fundamentals.py
+++ b/sparx/libpy/fundamentals.py
@@ -1848,7 +1848,15 @@ class symclass(object):
 					phi = (180.0+phi)%360.0; theta = 180.0 - theta; psi = (180.0 - psi)%360.0
 				elif( theta>90.0  and inc_mirror == 0 and not do_flip):
 					continue
-				phi = phi%qs
+
+				if( inc_mirror == 0 and not do_flip):
+					if 0 <= phi and phi < qs:
+						pass
+					else:
+						continue
+				else:
+					phi = phi%qs
+
 				if(self.sym[0] == "d"):
 					if( inc_mirror == 0 ):
 						if((self.nsym//2)%2 == 0):

--- a/sparx/libpy/fundamentals.py
+++ b/sparx/libpy/fundamentals.py
@@ -1770,7 +1770,7 @@ class symclass(object):
 		return sang
 
 
-	def reduce_anglesets(self, angles, inc_mirror=1):
+	def reduce_anglesets(self, angles, inc_mirror=1, do_flip=True):
 		#  Input is either list ot lists [[phi,thet,psi],[],[]] or a triplet [phi,thet,psi]
 		from math import degrees, radians, sin, cos, tan, atan, acos, sqrt
 		import types
@@ -1788,6 +1788,8 @@ class symclass(object):
 			phi = q[0]; theta = q[1]; psi = q[2]
 			if is_platonic_sym:
 				if(not self.is_in_subunit(phi, theta, 1)):
+					if inc_mirror == 0 and not do_flip:
+						continue
 					mat = rotmatrix(phi,theta,psi)
 					for l in range(self.nsym):
 						p1,p2,p3 = recmat( mulmat( mat , self.symatrix[l]) )
@@ -1801,13 +1803,20 @@ class symclass(object):
 							phi = self.brackets[1][0]-phi
 							if(l>0): psi = (360.0-psi)%360.0
 				elif(inc_mirror == 0):
-					if(phi>=self.brackets[0][0]):
+					if(phi>=self.brackets[0][0] and do_flip):
 						phi = self.brackets[1][0]-phi
 						psi = (360.0-psi)%360.0
+					elif(phi>=self.brackets[0][0] and not do_flip):
+						continue
 					elif(inc_mirror == 0):
-						if(phi>=self.brackets[0][0]):  phi = self.brackets[1][0]-phi
+						if(phi>=self.brackets[0][0] and do_flip):
+							phi = self.brackets[1][0]-phi
+						elif(phi>=self.brackets[0][0] and not do_flip):
+							continue
 			elif( self.sym[0] == "t" ):
 				if(not self.is_in_subunit(phi, theta, inc_mirror)):
+					if inc_mirror == 0 and not do_flip:
+						continue
 					mat = rotmatrix(phi,theta,psi)
 					fifi = False
 					for l in range(self.nsym):
@@ -1835,22 +1844,30 @@ class symclass(object):
 
 					if( not fifi ):  print("  FAILED mirror ")
 			else:
-				if( theta>90.0  and inc_mirror == 0 ):
+				if( theta>90.0  and inc_mirror == 0 and do_flip):
 					phi = (180.0+phi)%360.0; theta = 180.0 - theta; psi = (180.0 - psi)%360.0
+				elif( theta>90.0  and inc_mirror == 0 and not do_flip):
+					continue
 				phi = phi%qs
 				if(self.sym[0] == "d"):
 					if( inc_mirror == 0 ):
 						if((self.nsym//2)%2 == 0):
-							if(phi>=qs/2):
+							if(phi>=qs/2 and do_flip):
 								phi = qs-phi
 								psi = (360.0-psi)%360.0
+							elif(phi>=qs/2 and not do_flip):
+								continue
 						else:
-							if(phi>=360.0/self.nsym/2 and phi<360.0/self.nsym):
+							if(phi>=360.0/self.nsym/2 and phi<360.0/self.nsym and do_flip):
 								phi = 360.0/self.nsym-phi
 								psi = 360.0 - psi
-							elif(phi>=360.0/self.nsym+360.0/self.nsym/2 and phi<720.0/self.nsym):
+							elif(phi>=360.0/self.nsym/2 and phi<360.0/self.nsym and not do_flip):
+								continue
+							elif(phi>=360.0/self.nsym+360.0/self.nsym/2 and phi<720.0/self.nsym and do_flip):
 								phi = 720.0/self.nsym-phi+360.0/self.nsym
 								psi = (360.0-psi)%360.0
+							elif(phi>=360.0/self.nsym+360.0/self.nsym/2 and phi<720.0/self.nsym and not do_flip):
+								continue
 
 			redang.append([phi, theta, psi])
 


### PR DESCRIPTION
This fix is about symmetry wrapping during nearest neighbor searches.
A combination of 2 KDTrees is used.
One to find the best matching reference angles (c1 grid) for the data and one to find the best matching reference angles inside the asymmetric subunit (symmetry grid) for the previous reference angles (c1 grid).