### PR TITLE
Fix reinstallation of openmpi/pydusa

### DIFF
--- a/utils/build_and_install_openmpi.sh
+++ b/utils/build_and_install_openmpi.sh
@@ -5,5 +5,17 @@
 set -xe
 
 RECIPES_DIR=$(cd $(dirname $0)/../recipes && pwd -P)
-conda build ${RECIPES_DIR}/openmpi -c defaults -c conda-forge
-conda install openmpi --use-local --yes
+conda build ${RECIPES_DIR}/openmpi -c defaults -c conda-forge -c conda-forge/label/cf201901
+
+CONDA_BLD=$(dirname $(which conda))/../conda-bld
+if [[ ! -d ${CONDA_BLD} ]]
+then
+    CONDA_BLD=$(dirname ${CONDA_EXE})/../conda-bld
+fi
+if [[ ! -d ${CONDA_BLD} ]]
+then
+    echo "Conda-bld not found"
+    exit 1
+fi
+
+conda install openmpi -c file://${CONDA_BLD} --override-channels --yes

--- a/utils/build_and_install_openmpi.sh
+++ b/utils/build_and_install_openmpi.sh
@@ -7,15 +7,6 @@ set -xe
 RECIPES_DIR=$(cd $(dirname $0)/../recipes && pwd -P)
 conda build ${RECIPES_DIR}/openmpi -c defaults -c conda-forge -c conda-forge/label/cf201901
 
-CONDA_BLD=$(dirname $(which conda))/../conda-bld
-if [[ ! -d ${CONDA_BLD} ]]
-then
-    CONDA_BLD=$(dirname ${CONDA_EXE})/../conda-bld
-fi
-if [[ ! -d ${CONDA_BLD} ]]
-then
-    echo "Conda-bld not found"
-    exit 1
-fi
+CONDA_BLD=$(conda info --root)/conda-bld
 
 conda install openmpi -c file://${CONDA_BLD} --override-channels --yes

--- a/utils/install_pydusa_numpy.sh
+++ b/utils/install_pydusa_numpy.sh
@@ -14,18 +14,8 @@ set -xe
 RECIPES_DIR=$(cd $(dirname $0)/../recipes && pwd -P)
 numpy_version=${1//.}
 
-CONDA_BLD=$(dirname $(which conda))/../conda-bld
-if [[ ! -d ${CONDA_BLD} ]]
-then
-    CONDA_BLD=$(dirname ${CONDA_EXE})/../conda-bld
-fi
-if [[ ! -d ${CONDA_BLD} ]]
-then
-    echo "Conda-bld not found"
-    exit 1
-fi
+CONDA_BLD=$(conda info --root)/conda-bld
 
-#echo $(conda remove fftw-mpi --force --yes)
 conda install fftw-mpi --yes --force-reinstall --override-channels -c file://${CONDA_BLD}
 conda install pydusa=1.15=np${numpy_version}* --force-reinstall --yes -c file://${CONDA_BLD} --override-channels
 

--- a/utils/install_pydusa_numpy.sh
+++ b/utils/install_pydusa_numpy.sh
@@ -14,8 +14,19 @@ set -xe
 RECIPES_DIR=$(cd $(dirname $0)/../recipes && pwd -P)
 numpy_version=${1//.}
 
-conda remove fftw-mpi --force --yes
-conda install pydusa=1.15=np${numpy_version}* --use-local --yes
-conda install fftw-mpi --use-local --yes
+CONDA_BLD=$(dirname $(which conda))/../conda-bld
+if [[ ! -d ${CONDA_BLD} ]]
+then
+    CONDA_BLD=$(dirname ${CONDA_EXE})/../conda-bld
+fi
+if [[ ! -d ${CONDA_BLD} ]]
+then
+    echo "Conda-bld not found"
+    exit 1
+fi
+
+echo $(conda remove fftw-mpi --force --yes)
+conda install fftw-mpi --yes --override-channels -c file://${CONDA_BLD}
+conda install pydusa=1.15=np${numpy_version}* --yes -c file://${CONDA_BLD} --override-channels
 
 conda inspect linkages pydusa

--- a/utils/install_pydusa_numpy.sh
+++ b/utils/install_pydusa_numpy.sh
@@ -25,8 +25,8 @@ then
     exit 1
 fi
 
-echo $(conda remove fftw-mpi --force --yes)
-conda install fftw-mpi --yes --override-channels -c file://${CONDA_BLD}
-conda install pydusa=1.15=np${numpy_version}* --yes -c file://${CONDA_BLD} --override-channels
+#echo $(conda remove fftw-mpi --force --yes)
+conda install fftw-mpi --yes --force-reinstall --override-channels -c file://${CONDA_BLD}
+conda install pydusa=1.15=np${numpy_version}* --force-reinstall --yes -c file://${CONDA_BLD} --override-channels
 
 conda inspect linkages pydusa


### PR DESCRIPTION
Reinstalling OpenMPI on CentOS 7 caused a conda update which broke dependencies.

This way it works and in addition alows the usage of the systems OpenMPI