### PR TITLE
Remove EMAN2DIR, handle installation directory with e2getinstalldir()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,17 +70,6 @@ message_var(CMAKE_PREFIX_PATH)
 find_package(Python REQUIRED)
 find_package(NumPy  REQUIRED)
 
-# Write relative path that will be used to compute EMAN2DIR in libpyEM/EMAN2.py
-if(NOT WIN32)
-	set(eman2dir_relative_path "../../../")
-else()
-	set(eman2dir_relative_path "../../Library/")
-endif()
-
-if(SP_DIR)
-	file(WRITE ${SP_DIR}/eman2dir_relative_path_to_sp_dir ${eman2dir_relative_path})
-endif()
-
 set(CMAKE_INSTALL_RPATH "${SP_DIR};${EMAN_PREFIX_LIB}")
 
 OPTION(ENABLE_AUTODOC "enable latex/doxygen document generation and etc. " OFF)

--- a/libpyEM/EMAN2.py
+++ b/libpyEM/EMAN2.py
@@ -1788,7 +1788,7 @@ def get_3d_font_renderer():
 		font_renderer.set_depth(2)
 		pfm = get_platform()
 		if pfm in ["Linux","Darwin"]:
-			font_renderer.set_font_file_name(os.getenv("EMAN2DIR")+"/fonts/DejaVuSerif.ttf")
+			font_renderer.set_font_file_name(e2getinstalldir()+"/fonts/DejaVuSerif.ttf")
 		elif pfm == "Windows":
 			font_renderer.set_font_file_name("C:\\WINDOWS\\Fonts\\arial.ttf")
 		else:

--- a/libpyEM/EMAN2.py
+++ b/libpyEM/EMAN2.py
@@ -78,13 +78,6 @@ try:
 	os.putenv("LC_ALL","en_US.UTF-8")
 except: pass
 
-# Read relative path written by CMake and use that to get EMAN2DIR
-this_file_dirname = os.path.dirname(__file__)
-with open(os.path.join(this_file_dirname, 'eman2dir_relative_path_to_sp_dir'), 'r') as f:
-	eman2dir_relative_path_to_sp_dir = f.readline().strip()
-
-os.environ["EMAN2DIR"] = os.path.abspath(os.path.join(this_file_dirname, eman2dir_relative_path_to_sp_dir))
-
 # This block attempts to open the standard EMAN2 database interface
 # if it fails, it sets db to None. Applications can then alter their
 # behavior appropriately
@@ -373,10 +366,21 @@ This function will return a list of lists containing all currently set applicati
 	return ret2+ret
 
 def e2getinstalldir() :
-	"""platform independent path with '/'"""
-	url=os.getenv("EMAN2DIR")
+	"""Final path needs to be computed relative to a path within the installation.
+	 An alternative could be to get the installation directory from cmake,
+	 but cmake is not run during binary installations."""
+	
+	this_file_dirname = os.path.dirname(__file__)
+	if get_platform() != "Windows":
+		rel_path = '../../../'
+	else:
+		rel_path = '../../Library/'
+	
+	url=os.path.abspath(os.path.join(this_file_dirname, rel_path))
+	
 	if(sys.platform == 'win32'):
 		url=url.replace("\\","/")
+	
 	return url
 
 def numbered_path(prefix,makenew):

--- a/libpyEM/EMAN2.py
+++ b/libpyEM/EMAN2.py
@@ -376,12 +376,7 @@ def e2getinstalldir() :
 	else:
 		rel_path = '../../Library/'
 	
-	url=os.path.abspath(os.path.join(this_file_dirname, rel_path))
-	
-	if(sys.platform == 'win32'):
-		url=url.replace("\\","/")
-	
-	return url
+	return os.path.abspath(os.path.join(this_file_dirname, rel_path))
 
 def numbered_path(prefix,makenew):
 	"""Finds the next numbered path to use for a given prefix. ie- prefix='refine' if refine_01/EMAN2DB

--- a/libpyEM/EMAN2PAR.py
+++ b/libpyEM/EMAN2PAR.py
@@ -44,7 +44,7 @@ import os, getpass, socket, subprocess, threading, time,select,shutil, traceback
 from pickle import dumps,loads,dump,load
 
 from EMAN2jsondb import JSTask,JSTaskQueue,js_open_dict
-from EMAN2 import test_image,EMData,abs_path,local_datetime,EMUtil,Util,get_platform
+from EMAN2 import test_image,EMData,abs_path,local_datetime,EMUtil,Util,get_platform, e2getinstalldir
 
 DBUG=False		# If set will dump a bunch of debugging output, normally should be False
 
@@ -703,7 +703,7 @@ class EMLocalTaskHandler(object):
 					cmd+=" --loadmodule={}".format(self.module)
 					
 				if get_platform() == 'Windows':
-					cmd="python {}\\bin\\".format(os.getenv('EMAN2DIR'))+cmd
+					cmd="python {}\\bin\\".format(e2getinstalldir())+cmd
 					
 				proc=subprocess.Popen(cmd, shell=True)
 				self.running.append((proc,self.nextid))

--- a/programs/e2parallel.py
+++ b/programs/e2parallel.py
@@ -53,7 +53,7 @@ logid=None
 def load_module(module):
 	fname, cls=module.split('.')
 	#print("import {} from {}".format(cls, fname))
-	sys.path.append(os.path.join(os.getenv("EMAN2DIR"),"bin"))
+	sys.path.append(os.path.join(e2getinstalldir(),"bin"))
 	mod=__import__(fname, fromlist=[cls])
 	setattr(sys.modules["__main__"], cls, getattr(mod,cls))
 

--- a/programs/e2projectmanager.py
+++ b/programs/e2projectmanager.py
@@ -127,7 +127,7 @@ class EMProjectManager(QtWidgets.QMainWindow):
 		Load icons used for the tree. Additonal icons can be added using icons.json
 		"""
 		self.icons = {}
-		EMAN2DIR = os.getenv("EMAN2DIR")
+		EMAN2DIR = e2getinstalldir()
 
 		jsonfile = open(os.getenv("EMAN2DIR")+'/lib/pmconfig/icons.json', 'r')
 		data = jsonfile.read()
@@ -284,9 +284,9 @@ class EMProjectManager(QtWidgets.QMainWindow):
 		"""
 		self.tree_stacked_widget = QtWidgets.QStackedWidget()
 		self.tree_stacked_widget.setMinimumWidth(300)
-		self.tree_stacked_widget.addWidget(self.makeTreeWidget(os.getenv("EMAN2DIR")+'/lib/pmconfig/spr.json', 'Single Particle Refinement'))
-		self.tree_stacked_widget.addWidget(self.makeTreeWidget(os.getenv("EMAN2DIR")+'/lib/pmconfig/tomo.json', 'Tomography'))
-		self.tree_stacked_widget.addWidget(self.makeTreeWidget(os.getenv("EMAN2DIR")+'/lib/pmconfig/tomo_legacy.json', 'SPT (Legacy)'))
+		self.tree_stacked_widget.addWidget(self.makeTreeWidget(e2getinstalldir()+'/lib/pmconfig/spr.json', 'Single Particle Refinement'))
+		self.tree_stacked_widget.addWidget(self.makeTreeWidget(e2getinstalldir()+'/lib/pmconfig/tomo.json', 'Tomography'))
+		self.tree_stacked_widget.addWidget(self.makeTreeWidget(e2getinstalldir()+'/lib/pmconfig/tomo_legacy.json', 'SPT (Legacy)'))
 
 		return self.tree_stacked_widget
 
@@ -473,7 +473,7 @@ class EMProjectManager(QtWidgets.QMainWindow):
 		Load the wizard from a filebox
 		"""
 
-		jsonfile = open(os.getenv("EMAN2DIR")+self.getProgramWizardFile(), 'r')
+		jsonfile = open(e2getinstalldir()+self.getProgramWizardFile(), 'r')
 		data = jsonfile.read()
 		data = self.json_strip_comments(data)
 		wizarddata = json.loads(data)
@@ -569,7 +569,7 @@ class EMProjectManager(QtWidgets.QMainWindow):
 		Read in and return the usage from an e2program
 		"""
 		try:
-			f = open(os.getenv("EMAN2DIR")+"/bin/"+program,"r")
+			f = open(e2getinstalldir()+"/bin/"+program,"r")
 		except:
 			self.statusbar.setMessage("Can't open usage file '%s'"%program,"color:red;")
 			return
@@ -714,7 +714,7 @@ class EMProjectManager(QtWidgets.QMainWindow):
 		"""
 		parser = EMArgumentParser()
 		try:
-			f = open(os.getenv("EMAN2DIR")+"/bin/"+e2program,"r")
+			f = open(e2getinstalldir()+"/bin/"+e2program,"r")
 		except:
 			self.statusbar.setMessage("Can't open file '%s'"%e2program,"color:red;")
 			return

--- a/programs/e2projectmanager.py
+++ b/programs/e2projectmanager.py
@@ -129,7 +129,7 @@ class EMProjectManager(QtWidgets.QMainWindow):
 		self.icons = {}
 		EMAN2DIR = e2getinstalldir()
 
-		jsonfile = open(os.getenv("EMAN2DIR")+'/lib/pmconfig/icons.json', 'r')
+		jsonfile = open(EMAN2DIR+'/lib/pmconfig/icons.json', 'r')
 		data = jsonfile.read()
 		data = self.json_strip_comments(data)
 		tree = json.loads(data)

--- a/tests/test_EMAN2DIR.py
+++ b/tests/test_EMAN2DIR.py
@@ -15,7 +15,7 @@ files = [
     'lib/pmconfig/tomosegpanel.json', 
 ]
 
-eman2dir = os.getenv("EMAN2DIR")
+eman2dir = EMAN2.e2getinstalldir()
 print("EMAN2DIR: %s" % eman2dir)
 
 for f in files:


### PR DESCRIPTION
1. Removes usage of environment variable `EMAN2DIR` as the installation directory, instead `e2getinstalldir()` returns it now.
2. Cleans up unnecessarily introduced variable used for `EMAN2DIR` computation from `EMAN2.py`.
3. Removes writing the relative path needed to compute the installation directory to a file.
4. Should work similarly for binary and source installations, not like #298 which relies on cmake and doesn't work for binary installations.

Closes #298 .