### PR TITLE
Use size_t in insert_clip

### DIFF
--- a/libEM/emdata_transform.cpp
+++ b/libEM/emdata_transform.cpp
@@ -1769,37 +1769,37 @@ EMData*   EMData::bispecRotTransInvDirect(int type)
 
 
 void EMData::insert_clip(const EMData * const block, const IntPoint &origin) {
-	size_t nx1 = (size_t)block->get_xsize();
-	size_t ny1 = (size_t)block->get_ysize();
-	size_t nz1 = (size_t)block->get_zsize();
+	int nx1 = block->get_xsize();
+	int ny1 = block->get_ysize();
+	int nz1 = block->get_zsize();
 
 	Region area(origin[0], origin[1], origin[2],nx1, ny1, nz1);
 
 	//make sure the block fits in EMData 
-	size_t x0 = (size_t) area.origin[0];
+	int x0 = (int) area.origin[0];
 	x0 = x0 < 0 ? 0 : x0;
 
-	size_t y0 = (size_t) area.origin[1];
+	int y0 = (int) area.origin[1];
 	y0 = y0 < 0 ? 0 : y0;
 
-	size_t z0 = (size_t) area.origin[2];
+	int z0 = (int) area.origin[2];
 	z0 = z0 < 0 ? 0 : z0;
 
-	size_t x1 = (size_t) (area.origin[0] + area.size[0]);
+	int x1 = (int) (area.origin[0] + area.size[0]);
 	x1 = x1 > nx ? nx : x1;
 
-	size_t y1 = (size_t) (area.origin[1] + area.size[1]);
+	int y1 = (int) (area.origin[1] + area.size[1]);
 	y1 = y1 > ny ? ny : y1;
 
-	size_t z1 = (size_t) (area.origin[2] + area.size[2]);
+	int z1 = (int) (area.origin[2] + area.size[2]);
 	z1 = z1 > nz ? nz : z1;
 	if (z1 <= 0) {
 		z1 = 1;
 	}
 
-	size_t xd0 = (size_t) (area.origin[0] < 0 ? -area.origin[0] : 0);
-	size_t yd0 = (size_t) (area.origin[1] < 0 ? -area.origin[1] : 0);
-	size_t zd0 = (size_t) (area.origin[2] < 0 ? -area.origin[2] : 0);
+	int xd0 = (int) (area.origin[0] < 0 ? -area.origin[0] : 0);
+	int yd0 = (int) (area.origin[1] < 0 ? -area.origin[1] : 0);
+	int zd0 = (int) (area.origin[2] < 0 ? -area.origin[2] : 0);
 
 	if (x1 < x0 || y1 < y0 || z1 < z0) return; // out of bounds, this is fine, nothing happens
 
@@ -1828,8 +1828,8 @@ void EMData::insert_clip(const EMData * const block, const IntPoint &origin) {
 	}
 #endif
 */
-	float *src = block->get_data() + zd0 * src_secsize + yd0 * nx1 + xd0;
-	float *dst = get_data() + z0 * dst_secsize + y0 * nx + x0;
+	float *src = block->get_data() + (size_t)zd0 * (size_t)src_secsize + (size_t)yd0 * (size_t)nx1 + (size_t)xd0;
+	float *dst = get_data() + (size_t)z0 * (size_t)dst_secsize + (size_t)y0 * (size_t)nx + (size_t)x0;
 	
 	size_t src_gap = src_secsize - (y1-y0) * nx1;
 	size_t dst_gap = dst_secsize - (y1-y0) * nx;

--- a/libEM/emdata_transform.cpp
+++ b/libEM/emdata_transform.cpp
@@ -1769,37 +1769,37 @@ EMData*   EMData::bispecRotTransInvDirect(int type)
 
 
 void EMData::insert_clip(const EMData * const block, const IntPoint &origin) {
-	int nx1 = block->get_xsize();
-	int ny1 = block->get_ysize();
-	int nz1 = block->get_zsize();
+	size_t nx1 = (size_t)block->get_xsize();
+	size_t ny1 = (size_t)block->get_ysize();
+	size_t nz1 = (size_t)block->get_zsize();
 
 	Region area(origin[0], origin[1], origin[2],nx1, ny1, nz1);
 
 	//make sure the block fits in EMData 
-	int x0 = (int) area.origin[0];
+	size_t x0 = (size_t) area.origin[0];
 	x0 = x0 < 0 ? 0 : x0;
 
-	int y0 = (int) area.origin[1];
+	size_t y0 = (size_t) area.origin[1];
 	y0 = y0 < 0 ? 0 : y0;
 
-	int z0 = (int) area.origin[2];
+	size_t z0 = (size_t) area.origin[2];
 	z0 = z0 < 0 ? 0 : z0;
 
-	int x1 = (int) (area.origin[0] + area.size[0]);
+	size_t x1 = (size_t) (area.origin[0] + area.size[0]);
 	x1 = x1 > nx ? nx : x1;
 
-	int y1 = (int) (area.origin[1] + area.size[1]);
+	size_t y1 = (size_t) (area.origin[1] + area.size[1]);
 	y1 = y1 > ny ? ny : y1;
 
-	int z1 = (int) (area.origin[2] + area.size[2]);
+	size_t z1 = (size_t) (area.origin[2] + area.size[2]);
 	z1 = z1 > nz ? nz : z1;
 	if (z1 <= 0) {
 		z1 = 1;
 	}
 
-	int xd0 = (int) (area.origin[0] < 0 ? -area.origin[0] : 0);
-	int yd0 = (int) (area.origin[1] < 0 ? -area.origin[1] : 0);
-	int zd0 = (int) (area.origin[2] < 0 ? -area.origin[2] : 0);
+	size_t xd0 = (size_t) (area.origin[0] < 0 ? -area.origin[0] : 0);
+	size_t yd0 = (size_t) (area.origin[1] < 0 ? -area.origin[1] : 0);
+	size_t zd0 = (size_t) (area.origin[2] < 0 ? -area.origin[2] : 0);
 
 	if (x1 < x0 || y1 < y0 || z1 < z0) return; // out of bounds, this is fine, nothing happens
 

--- a/rt/pyem/test_emdata.py
+++ b/rt/pyem/test_emdata.py
@@ -298,7 +298,7 @@ class TestEMData(unittest.TestCase):
                 e.insert_clip( e2,(30,30,30) )
             except RuntimeError as runtime_err:
                 self.assertEqual(exception_type(runtime_err), "ImageFormatException")
-        
+
         e.insert_clip(e2, (16,16,16))
         d1 = e.get_3dview()
         d2 = e2.get_3dview()
@@ -306,6 +306,34 @@ class TestEMData(unittest.TestCase):
             for j in range(10):
                 for i in range(10):
                     self.assertEqual(d1[i+16][j+16][k+16], d2[i][j][k])
+
+    def test_insert_clip_large(self):
+        """test insert_clip_large() function ......................"""
+        e = EMData()
+        e.set_size(30000, 80000, 1)
+        e.to_zero()
+        e.process_inplace("testimage.noise.uniform.rand")
+        
+        e2 = EMData()
+        e2.set_size(30000, 1, 1)
+        e2.to_zero()
+        e2.process_inplace("testimage.noise.uniform.rand")
+
+        if(IS_TEST_EXCEPTION):
+            #test exception if the clip is out side of the image
+            self.assertRaises( RuntimeError, e.insert_clip, e2, (79998, 79998, 79998) )
+            try:
+                e.insert_clip( e2,(79998, 79998, 79998) )
+            except RuntimeError as runtime_err:
+                self.assertEqual(exception_type(runtime_err), "ImageFormatException")
+
+        e.insert_clip(e2, (0,71583))
+        d1 = e.get_3dview()
+        d2 = e2.get_3dview()
+        for k in range(10):
+            for j in range(1):
+                for i in range(1):
+                    self.assertEqual(d1[i][j+71583][k], d2[i][j][k])
 
     def test_get_top_half(self):
         """test get_top_half() function ....................."""

--- a/rt/pyem/test_emdata.py
+++ b/rt/pyem/test_emdata.py
@@ -307,33 +307,33 @@ class TestEMData(unittest.TestCase):
                 for i in range(10):
                     self.assertEqual(d1[i+16][j+16][k+16], d2[i][j][k])
 
-    def test_insert_clip_large(self):
-        """test insert_clip_large() function ......................"""
-        e = EMData()
-        e.set_size(30000, 80000, 1)
-        e.to_zero()
-        e.process_inplace("testimage.noise.uniform.rand")
-        
-        e2 = EMData()
-        e2.set_size(30000, 1, 1)
-        e2.to_zero()
-        e2.process_inplace("testimage.noise.uniform.rand")
+    #def test_insert_clip_large(self):
+    #    """test insert_clip_large() function ......................"""
+    #    e = EMData()
+    #    e.set_size(30000, 80000, 1)
+    #    e.to_zero()
+    #    e.process_inplace("testimage.noise.uniform.rand")
+    #    
+    #    e2 = EMData()
+    #    e2.set_size(30000, 1, 1)
+    #    e2.to_zero()
+    #    e2.process_inplace("testimage.noise.uniform.rand")
 
-        if(IS_TEST_EXCEPTION):
-            #test exception if the clip is out side of the image
-            self.assertRaises( RuntimeError, e.insert_clip, e2, (79998, 79998, 79998) )
-            try:
-                e.insert_clip( e2,(79998, 79998, 79998) )
-            except RuntimeError as runtime_err:
-                self.assertEqual(exception_type(runtime_err), "ImageFormatException")
+    #    if(IS_TEST_EXCEPTION):
+    #        #test exception if the clip is out side of the image
+    #        self.assertRaises( RuntimeError, e.insert_clip, e2, (79998, 79998, 79998) )
+    #        try:
+    #            e.insert_clip( e2,(79998, 79998, 79998) )
+    #        except RuntimeError as runtime_err:
+    #            self.assertEqual(exception_type(runtime_err), "ImageFormatException")
 
-        e.insert_clip(e2, (0,71583))
-        d1 = e.get_3dview()
-        d2 = e2.get_3dview()
-        for k in range(10):
-            for j in range(1):
-                for i in range(1):
-                    self.assertEqual(d1[i][j+71583][k], d2[i][j][k])
+    #    e.insert_clip(e2, (0,71583))
+    #    d1 = e.get_3dview()
+    #    d2 = e2.get_3dview()
+    #    for k in range(10):
+    #        for j in range(1):
+    #            for i in range(1):
+    #                self.assertEqual(d1[i][j+71583][k], d2[i][j][k])
 
     def test_get_top_half(self):
         """test get_top_half() function ....................."""


### PR DESCRIPTION
Hello Steve,

The problem is related to the observation you made, but at another place.
I replaced the int types with size_t types and now it is also working with large EMData objects.

However, I am far away from being an expert in C++, so feedback is highly appreciated (e.g. I am not sure it if it is better to make all variables size_t or cast them as size_t if they are needed).

The actual problem are the pointers src and dst in line 1831 and 1832, which caused the memcpy function to throw the segmentation fault.

Best,
Markus
