### PR TITLE
Helical fabian 2

### DIFF
--- a/sparx/bin/sx3dvariability.py
+++ b/sparx/bin/sx3dvariability.py
@@ -43,8 +43,11 @@ from	EMAN2 		import EMUtil
 import	os
 import	sys
 from 	time		import	time
+
 import mpi
 from mpi import *
+
+mpi.mpi_init( 0, [] )
 
 """
 Instruction:
@@ -109,7 +112,7 @@ def main():
 
 	(options,args) = parser.parse_args()
 	#####
-	from mpi import mpi_init, mpi_comm_rank, mpi_comm_size, mpi_recv, MPI_COMM_WORLD
+	from mpi import mpi_comm_rank, mpi_comm_size, mpi_recv, MPI_COMM_WORLD
 	from mpi import mpi_barrier, mpi_reduce, mpi_bcast, mpi_send, MPI_FLOAT, MPI_SUM, MPI_INT, MPI_MAX
 	#from mpi import *
 	from applications   import MPI_start_end
@@ -138,17 +141,10 @@ def main():
 	if options.output_dir =="./": current_output_dir = os.path.abspath(options.output_dir)
 	else: current_output_dir = options.output_dir
 	if options.symmetrize :
-		if RUNNING_UNDER_MPI:
-			try:
-				sys.argv = mpi_init(len(sys.argv), sys.argv)
-				try:	
-					number_of_proc = mpi_comm_size(MPI_COMM_WORLD)
-					if( number_of_proc > 1 ):
-						ERROR( "Cannot use more than one CPU for symmetry preparation" )
-				except:
-					pass
-			except:
-				pass
+
+		if mpi.mpi_comm_size(MPI_COMM_WORLD) > 1:
+			ERROR( "Cannot use more than one CPU for symmetry preparation" )
+
 		if not os.path.exists(current_output_dir): os.makedirs(current_output_dir)
 		
 		#  Input
@@ -220,7 +216,6 @@ def main():
 	else:
 
 		from fundamentals import window2d
-		sys.argv       = mpi_init(len(sys.argv), sys.argv)
 		myid           = mpi_comm_rank(MPI_COMM_WORLD)
 		number_of_proc = mpi_comm_size(MPI_COMM_WORLD)
 		main_node      = 0

--- a/sparx/bin/sx_real.py
+++ b/sparx/bin/sx_real.py
@@ -38,8 +38,8 @@ from __future__ import print_function
 import EMAN2
 from EMAN2 import *
 
-
 GUIUSE=True
+
 try:
 	if get_platform()=="Linux" and os.getenv("DISPLAY")==None: raise Exception
 

--- a/sparx/bin/sxali2d.py
+++ b/sparx/bin/sxali2d.py
@@ -44,6 +44,8 @@ import sys
 
 import mpi
 
+mpi.mpi_init( 0, [] )
+
 def main():
 	progname = os.path.basename(sys.argv[0])
 	usage = progname + " stack outdir <maskfile> --ir=inner_radius --ou=outer_radius --rs=ring_step --xr=x_range --yr=y_range --ts=translation_step --dst=delta --center=center --maxit=max_iteration --CTF --snr=SNR --Fourvar=Fourier_variance --Ng=group_number --Function=user_function_name --CUDA --GPUID --MPI"
@@ -104,8 +106,7 @@ def main():
 		global_def.BATCH = True
 		if  options.MPI:
 			from applications import ali2d_base
-			from mpi import mpi_init, mpi_comm_size, mpi_comm_rank, MPI_COMM_WORLD
-			sys.argv = mpi_init(len(sys.argv),sys.argv)
+			from mpi import mpi_comm_size, mpi_comm_rank, MPI_COMM_WORLD
 
 			number_of_proc = mpi_comm_size(MPI_COMM_WORLD)
 			myid = mpi_comm_rank(MPI_COMM_WORLD)
@@ -151,5 +152,4 @@ if __name__ == "__main__":
 	global_def.print_timestamp( "Start" )
 	main()
 	global_def.print_timestamp( "Finish" )
-	if "OMPI_COMM_WORLD_SIZE" in os.environ:
-		mpi.mpi_finalize()
+	mpi.mpi_finalize()

--- a/sparx/bin/sxali3d.py
+++ b/sparx/bin/sxali3d.py
@@ -42,6 +42,9 @@ import sys
 
 import mpi
 
+mpi.mpi_init( 0, [] )
+
+
 def main():
 
 	arglist = []
@@ -96,9 +99,6 @@ def main():
 			mask = None
 		else:
 			mask = args[3]
-		if options.MPI:
-			from mpi import mpi_init, mpi_finalize
-			sys.argv = mpi_init(len(sys.argv), sys.argv)
 
 		if global_def.CACHE_DISABLE:
 			from utilities import disable_bdb_cache
@@ -183,5 +183,4 @@ if __name__ == "__main__":
 	global_def.print_timestamp( "Start" )
 	main()
 	global_def.print_timestamp( "Finish" )
-	if "OMPI_COMM_WORLD_SIZE" in os.environ:
-		mpi.mpi_finalize()
+	mpi.mpi_finalize()

--- a/sparx/bin/sxcenter_projections.py
+++ b/sparx/bin/sxcenter_projections.py
@@ -42,11 +42,6 @@ from logger import Logger, BaseLogger_Files
 import global_def
 from global_def import sxprint, ERROR
 
-from mpi   import  *
-from math  import  *
-
-
-
 import os
 import sys
 import subprocess
@@ -54,8 +49,6 @@ import time
 import string
 from   sys import exit
 from   time import localtime, strftime
-
-
 
 from utilities import write_text_row, drop_image, model_gauss_noise, get_im, set_params_proj, wrap_mpi_bcast, model_circle
 import user_functions
@@ -70,8 +63,11 @@ import os
 import time
 import socket
 
+import mpi
+from mpi   import  *
+from math  import  *
 
-mpi_init(0, [])
+mpi.mpi_init( 0, [] )
 
 
 def subdict(d,u):
@@ -469,4 +465,4 @@ if __name__=="__main__":
 	global_def.print_timestamp( "Start" )
 	main()
 	global_def.print_timestamp( "Finish" )
-	mpi_finalize()
+	mpi.mpi_finalize()

--- a/sparx/bin/sxcompute_isac_avg.py
+++ b/sparx/bin/sxcompute_isac_avg.py
@@ -26,7 +26,6 @@ from    numpy      import array
 from    logger     import Logger, BaseLogger_Files
 
 import mpi
-from mpi import *
 
 from math import *
 
@@ -42,7 +41,7 @@ from optparse   import OptionParser
 from EMAN2      import EMData
 from logger     import Logger, BaseLogger_Files
 
-from utilities 		import get_im, bcast_number_to_all, write_text_file,read_text_file,wrap_mpi_bcast, write_text_row
+from utilities 		import get_im, bcast_number_to_all, write_text_file, read_text_file, wrap_mpi_bcast, write_text_row
 from utilities 		import cmdexecute
 from filter			import filt_tanl
 import user_functions
@@ -172,31 +171,28 @@ def main():
 			
 	(options, args) = parser.parse_args(sys.argv[1:])
 	
-	adjust_to_analytic_model = False
-	adjust_to_given_pw2      = False
-	B_enhance                = False
-	no_adjustment            = False
+	adjust_to_analytic_model = True if options.pw_adjustment=='analytical_model' else False
+	no_adjustment            = True if options.pw_adjustment=='no_adjustment'    else False
+	B_enhance                = True if options.pw_adjustment=='bfactor'          else False
+	adjust_to_given_pw2      = True if not (adjust_to_analytic_model or no_adjustment or B_enhance) else False
 
-	if   options.pw_adjustment=='analytical_model':   adjust_to_analytic_model = True
-	elif options.pw_adjustment=='no_adjustment':      no_adjustment            = True
-	elif options.pw_adjustment=='bfactor':            B_enhance                = True
-	else:                                             adjust_to_given_pw2      = True 
-
-	nproc    = mpi_comm_size(MPI_COMM_WORLD)
-	myid     = mpi_comm_rank(MPI_COMM_WORLD)
-
+	# mpi
+	nproc = mpi.mpi_comm_size(mpi.MPI_COMM_WORLD)
+	myid  = mpi.mpi_comm_rank(mpi.MPI_COMM_WORLD)
 
 	Blockdata = {}
-	#  MPI stuff
-	Blockdata["nproc"]              = nproc
-	Blockdata["myid"]               = myid
-	Blockdata["main_node"]          = 0
-	Blockdata["shared_comm"]                    = mpi_comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED,  0, MPI_INFO_NULL)
-	Blockdata["myid_on_node"]                   = mpi_comm_rank(Blockdata["shared_comm"])
-	Blockdata["no_of_processes_per_group"]      = mpi_comm_size(Blockdata["shared_comm"])
-	masters_from_groups_vs_everything_else_comm = mpi_comm_split(MPI_COMM_WORLD, Blockdata["main_node"] == Blockdata["myid_on_node"], Blockdata["myid_on_node"])
-	Blockdata["color"], Blockdata["no_of_groups"], balanced_processor_load_on_nodes = get_colors_and_subsets(Blockdata["main_node"], MPI_COMM_WORLD, Blockdata["myid"], \
-			 Blockdata["shared_comm"], Blockdata["myid_on_node"], masters_from_groups_vs_everything_else_comm)
+	Blockdata["nproc"]     = nproc
+	Blockdata["myid"]      = myid
+	Blockdata["main_node"] = 0
+	Blockdata["shared_comm"]                    = mpi.mpi_comm_split_type(mpi.MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED,  0, MPI_INFO_NULL)
+	Blockdata["myid_on_node"]                   = mpi.mpi_comm_rank(Blockdata["shared_comm"])
+	Blockdata["no_of_processes_per_group"]      = mpi.mpi_comm_size(Blockdata["shared_comm"])
+	masters_from_groups_vs_everything_else_comm = mpi.mpi_comm_split( mpi.MPI_COMM_WORLD, Blockdata["main_node"] == Blockdata["myid_on_node"], Blockdata["myid_on_node"])
+	Blockdata["color"], Blockdata["no_of_groups"], balanced_processor_load_on_nodes = get_colors_and_subsets( Blockdata["main_node"],
+																											  mpi.MPI_COMM_WORLD, Blockdata["myid"],
+																											  Blockdata["shared_comm"], 
+																											  Blockdata["myid_on_node"], 
+																											  masters_from_groups_vs_everything_else_comm )
 	#  We need two nodes for processing of volumes
 	Blockdata["node_volume"] = [Blockdata["no_of_groups"]-3, Blockdata["no_of_groups"]-2, Blockdata["no_of_groups"]-1]  # For 3D stuff take three last nodes
 	#  We need two CPUs for processing of volumes, they are taken to be main CPUs on each volume
@@ -212,7 +208,7 @@ def main():
 		checking_flag = 0
 		if(Blockdata["myid"] == Blockdata["main_node"]):
 			if not os.path.exists(options.pw_adjustment): checking_flag = 1
-		checking_flag = bcast_number_to_all(checking_flag, Blockdata["main_node"], MPI_COMM_WORLD)
+		checking_flag = bcast_number_to_all(checking_flag, Blockdata["main_node"], mpi.MPI_COMM_WORLD)
 		
 		if checking_flag ==1: 
 			ERROR( "User provided power spectrum does not exist", myid=Blockdata["myid"] )
@@ -267,8 +263,8 @@ def main():
 		if not os.path.exists(subdir_path): os.mkdir(subdir_path)
 		li =len(masterdir)
 	else: li = 0
-	li                                  = mpi_bcast(li,1,MPI_INT,Blockdata["main_node"],MPI_COMM_WORLD)[0]
-	masterdir							= mpi_bcast(masterdir,li,MPI_CHAR,Blockdata["main_node"],MPI_COMM_WORLD)
+	li                                  = mpi.mpi_bcast(li,1,mpi.MPI_INT,Blockdata["main_node"],mpi.MPI_COMM_WORLD)[0]
+	masterdir							= mpi.mpi_bcast(masterdir,li,mpi.MPI_CHAR,Blockdata["main_node"],mpi.MPI_COMM_WORLD)
 	masterdir                           = string.join(masterdir,"")
 	Tracker["constants"]["masterdir"]	= masterdir
 	log_main = Logger(BaseLogger_Files())
@@ -277,7 +273,7 @@ def main():
 	while not os.path.exists(Tracker["constants"]["masterdir"]):
 		sxprint("Node ", Blockdata["myid"], "  waiting...", Tracker["constants"]["masterdir"])
 		sleep(1)
-	mpi_barrier(MPI_COMM_WORLD)
+	mpi.mpi_barrier(mpi.MPI_COMM_WORLD)
 
 	if(Blockdata["myid"] == Blockdata["main_node"]):
 		init_dict = {}
@@ -287,7 +283,7 @@ def main():
 		for im in range(len(core)): init_dict[im]  = core[im]
 		del core
 	else: init_dict = 0
-	init_dict = wrap_mpi_bcast(init_dict, Blockdata["main_node"], communicator = MPI_COMM_WORLD)
+	init_dict = wrap_mpi_bcast(init_dict, Blockdata["main_node"], communicator = mpi.MPI_COMM_WORLD)
 	###
 	do_ctf = True
 	if options.noctf: do_ctf = False 
@@ -327,7 +323,7 @@ def main():
 		print("ISAC particle radius : {0}".format(isac_radius))
 		Tracker["ini_shrink"] = isac_shrink_ratio
 	else: Tracker["ini_shrink"] = 0.0
-	Tracker = wrap_mpi_bcast(Tracker, Blockdata["main_node"], communicator = MPI_COMM_WORLD)
+	Tracker = wrap_mpi_bcast(Tracker, Blockdata["main_node"], communicator = mpi.MPI_COMM_WORLD)
 
 	#print(Tracker["constants"]["pixel_size"], "pixel_size")	
 	x_range = max(Tracker["constants"]["xrange"], int(1./Tracker["ini_shrink"]+0.99999) )
@@ -335,7 +331,7 @@ def main():
 
 	if(Blockdata["myid"] == Blockdata["main_node"]): parameters = read_text_row(os.path.join(Tracker["constants"]["isac_dir"], "all_parameters.txt"))
 	else: parameters = 0
-	parameters = wrap_mpi_bcast(parameters, Blockdata["main_node"], communicator = MPI_COMM_WORLD)		
+	parameters = wrap_mpi_bcast(parameters, Blockdata["main_node"], communicator = mpi.MPI_COMM_WORLD)		
 	params_dict = {}
 	list_dict   = {}
 	#parepare params_dict
@@ -373,9 +369,9 @@ def main():
 		params_dict = 0
 		list_dict   = 0
 		memlist     = 0
-	params_dict = wrap_mpi_bcast(params_dict, Blockdata["main_node"], communicator = MPI_COMM_WORLD)
-	list_dict   = wrap_mpi_bcast(list_dict, Blockdata["main_node"], communicator = MPI_COMM_WORLD)
-	memlist     = wrap_mpi_bcast(memlist, Blockdata["main_node"], communicator = MPI_COMM_WORLD)
+	params_dict = wrap_mpi_bcast(params_dict, Blockdata["main_node"], communicator = mpi.MPI_COMM_WORLD)
+	list_dict   = wrap_mpi_bcast(list_dict, Blockdata["main_node"], communicator = mpi.MPI_COMM_WORLD)
+	memlist     = wrap_mpi_bcast(memlist, Blockdata["main_node"], communicator = mpi.MPI_COMM_WORLD)
 	# Now computing!
 	del init_dict
 	tag_sharpen_avg = 1000
@@ -383,133 +379,132 @@ def main():
 	enforced_to_H1 = False
 	if B_enhance:
 		if Tracker["constants"]["low_pass_filter"] == -1.0: enforced_to_H1 = True
-	if navg <Blockdata["nproc"]:#  Each CPU do one average 
-		ERROR("number of nproc is larger than number of averages", "sxcompute_isac_avg.py", 1, Blockdata["myid"])
+
+	# distribute workload among mpi processes
+	image_start,image_end = MPI_start_end(navg, Blockdata["nproc"], Blockdata["myid"])
+
+	if Blockdata["myid"] == Blockdata["main_node"]:
+		cpu_dict = {}
+		for iproc in range(Blockdata["nproc"]):
+			local_image_start, local_image_end = MPI_start_end(navg, Blockdata["nproc"], iproc)
+			for im in range(local_image_start, local_image_end):
+				cpu_dict [im] = iproc
 	else:
-		FH_list  = [ [0, 0.0, 0.0] for im in range(navg)]
-		image_start,image_end = MPI_start_end(navg, Blockdata["nproc"], Blockdata["myid"])
-		if Blockdata["myid"] == Blockdata["main_node"]:
-			cpu_dict = {}
-			for iproc in range(Blockdata["nproc"]):
-				local_image_start, local_image_end = MPI_start_end(navg, Blockdata["nproc"], iproc)
-				for im in range(local_image_start, local_image_end): cpu_dict [im] = iproc
-		else:  cpu_dict = 0
-		cpu_dict = wrap_mpi_bcast(cpu_dict, Blockdata["main_node"], communicator = MPI_COMM_WORLD)
+		cpu_dict = 0
 	
-		slist      = [None for im in range(navg)]
-		ini_list   = [None for im in range(navg)]
-		avg1_list  = [None for im in range(navg)]
-		avg2_list  = [None for im in range(navg)]
-		plist_dict = {}
+	cpu_dict = wrap_mpi_bcast(cpu_dict, Blockdata["main_node"], communicator = mpi.MPI_COMM_WORLD)
+
+
+	slist      = [None for im in range(navg)]
+	ini_list   = [None for im in range(navg)]
+	avg1_list  = [None for im in range(navg)]
+	avg2_list  = [None for im in range(navg)]
+	data_list  = [ None for im in range(navg)]
+	plist_dict = {}
+	
+	if Blockdata["myid"] == Blockdata["main_node"]:
+		if B_enhance: 
+			sxprint("Avg ID   B-factor  FH1(Res before ali) FH2(Res after ali)")	
+		else: 
+			sxprint("Avg ID   FH1(Res before ali)  FH2(Res after ali)")
+
+	FH_list = [ [0, 0.0, 0.0] for im in range(navg)]
+	for iavg in range(image_start,image_end):
+
+		mlist = EMData.read_images(Tracker["constants"]["orgstack"], list_dict[iavg])
+
+		for im in range(len(mlist)):
+			set_params2D(mlist[im], params_dict[iavg][im], xform = "xform.align2d")
 		
-		data_list  = [ None for im in range(navg)]
-		if Blockdata["myid"] == Blockdata["main_node"]:
-			if B_enhance: sxprint("Avg ID   B-factor  FH1(Res before ali) FH2(Res after ali)")	
-			else: sxprint("Avg ID   FH1(Res before ali)  FH2(Res after ali)")	
-		for iavg in range(image_start,image_end):
-			mlist = EMData.read_images(Tracker["constants"]["orgstack"], list_dict[iavg])
-			for im in range(len(mlist)):
-				#mlist[im]= get_im(Tracker["constants"]["orgstack"], list_dict[iavg][im])
-				set_params2D(mlist[im], params_dict[iavg][im], xform = "xform.align2d")
-			
-			if options.local_alignment:
-				"""
-				new_average1 = within_group_refinement([mlist[kik] for kik in range(0,len(mlist),2)], maskfile= None, randomize= False, ir=1.0,  \
-				 ou=Tracker["constants"]["radius"], rs=1.0, xrng=[x_range], yrng=[y_range], step=[Tracker["constants"]["xstep"]], \
-				 dst=0.0, maxit=Tracker["constants"]["maxit"], FH=max(Tracker["constants"]["FH"], FH1), FF=0.02, method="")
-				new_average2 = within_group_refinement([mlist[kik] for kik in range(1,len(mlist),2)], maskfile= None, randomize= False, ir=1.0, \
-				 ou= Tracker["constants"]["radius"], rs=1.0, xrng=[ x_range], yrng=[y_range], step=[Tracker["constants"]["xstep"]], \
-				 dst=0.0, maxit=Tracker["constants"]["maxit"], FH = max(Tracker["constants"]["FH"], FH1), FF=0.02, method="")
-				new_avg, frc, plist = compute_average(mlist, Tracker["constants"]["radius"], do_ctf)
-				"""
-				new_avg, plist, FH2 = refinement_2d_local(mlist, Tracker["constants"]["radius"], a_range,x_range, y_range, CTF = do_ctf, SNR=1.0e10)
+		if options.local_alignment:
+			new_avg, plist, FH2 = refinement_2d_local(mlist, Tracker["constants"]["radius"], a_range,x_range, y_range, CTF = do_ctf, SNR=1.0e10)
+			plist_dict[iavg] = plist
+			FH1 = -1.0
 
-				plist_dict[iavg] = plist
-				FH1 = -1.0
-			else:
-				new_avg, frc, plist = compute_average(mlist, Tracker["constants"]["radius"], do_ctf)
-				FH1 = get_optimistic_res(frc)
-				FH2 = -1.0
-			#write_text_file(frc, os.path.join(Tracker["constants"]["masterdir"], "fsc%03d.txt"%iavg))
-			FH_list[iavg] = [iavg, FH1, FH2]
-			
-			if B_enhance:
-				new_avg, gb = apply_enhancement(new_avg, Tracker["constants"]["B_start"], Tracker["constants"]["pixel_size"], Tracker["constants"]["Bfactor"])
-				sxprint("  %6d      %6.3f  %4.3f  %4.3f"%(iavg, gb, FH1, FH2))
-				
-			elif adjust_to_given_pw2: 
-				roo = read_text_file( Tracker["constants"]["modelpw"], -1)
-				roo = roo[0] # always on the first column
-				new_avg = adjust_pw_to_model(new_avg, Tracker["constants"]["pixel_size"], roo)
-				sxprint("  %6d      %4.3f  %4.3f  "%(iavg, FH1, FH2))
-				
-			elif adjust_to_analytic_model:
-				new_avg = adjust_pw_to_model(new_avg, Tracker["constants"]["pixel_size"], None)
-				sxprint("  %6d      %4.3f  %4.3f   "%(iavg, FH1, FH2))
+		else:
+			new_avg, frc, plist = compute_average(mlist, Tracker["constants"]["radius"], do_ctf)
+			FH1 = get_optimistic_res(frc)
+			FH2 = -1.0
 
-			elif no_adjustment: pass
-			
-			if Tracker["constants"]["low_pass_filter"] != -1.0:
-				if Tracker["constants"]["low_pass_filter"] == 0.0: low_pass_filter = FH1
-				elif Tracker["constants"]["low_pass_filter"] == 1.0: 
-					low_pass_filter = FH2
-					if not options.local_alignment: low_pass_filter = FH1
-				else: 
-					low_pass_filter = Tracker["constants"]["low_pass_filter"]
-					if low_pass_filter >=0.45: low_pass_filter =0.45 		
-				new_avg = filt_tanl(new_avg, low_pass_filter, 0.02)
-			else:# No low pass filter but if enforced
-				if enforced_to_H1: new_avg = filt_tanl(new_avg, FH1, 0.02)
-			if B_enhance: new_avg = fft(new_avg)
-				
-			new_avg.set_attr("members",   list_dict[iavg])
-			new_avg.set_attr("n_objects", len(list_dict[iavg]))
-			slist[iavg]    = new_avg
-			sxprint(strftime("%Y-%m-%d_%H:%M:%S", localtime()) + " =>",  "Refined average %7d"%iavg)
-			
-		## send to main node to write
-		mpi_barrier(MPI_COMM_WORLD)
-
+		FH_list[iavg] = [iavg, FH1, FH2]
 		
-		for im in range(navg):
-			# avg
-			if cpu_dict[im] == Blockdata["myid"] and Blockdata["myid"] != Blockdata["main_node"]:
-				send_EMData(slist[im], Blockdata["main_node"],  tag_sharpen_avg)
+		if B_enhance:
+			new_avg, gb = apply_enhancement(new_avg, Tracker["constants"]["B_start"], Tracker["constants"]["pixel_size"], Tracker["constants"]["Bfactor"])
+			sxprint("  %6d      %6.3f  %4.3f  %4.3f"%(iavg, gb, FH1, FH2))
 			
-			elif cpu_dict[im] == Blockdata["myid"] and Blockdata["myid"] == Blockdata["main_node"]:
-				slist[im].set_attr("members", memlist[im])
-				slist[im].set_attr("n_objects", len(memlist[im]))
-				slist[im].write_image(os.path.join(Tracker["constants"]["masterdir"], "class_averages.hdf"), im)
+		elif adjust_to_given_pw2: 
+			roo = read_text_file( Tracker["constants"]["modelpw"], -1)
+			roo = roo[0] # always on the first column
+			new_avg = adjust_pw_to_model(new_avg, Tracker["constants"]["pixel_size"], roo)
+			sxprint("  %6d      %4.3f  %4.3f  "%(iavg, FH1, FH2))
 			
-			elif cpu_dict[im] != Blockdata["myid"] and Blockdata["myid"] == Blockdata["main_node"]:
-				new_avg_other_cpu = recv_EMData(cpu_dict[im], tag_sharpen_avg)
-				new_avg_other_cpu.set_attr("members", memlist[im])
-				new_avg_other_cpu.set_attr("n_objects", len(memlist[im]))
-				new_avg_other_cpu.write_image(os.path.join(Tracker["constants"]["masterdir"], "class_averages.hdf"), im)
+		elif adjust_to_analytic_model:
+			new_avg = adjust_pw_to_model(new_avg, Tracker["constants"]["pixel_size"], None)
+			sxprint("  %6d      %4.3f  %4.3f   "%(iavg, FH1, FH2))
+
+		elif no_adjustment: pass
+		
+		if Tracker["constants"]["low_pass_filter"] != -1.0:di
+			if Tracker["constants"]["low_pass_filter"] == 0.0: low_pass_filter = FH1
+			elif Tracker["constants"]["low_pass_filter"] == 1.0: 
+				low_pass_filter = FH2
+				if not options.local_alignment: low_pass_filter = FH1
+			else: 
+				low_pass_filter = Tracker["constants"]["low_pass_filter"]
+				if low_pass_filter >=0.45: low_pass_filter =0.45 		
+			new_avg = filt_tanl(new_avg, low_pass_filter, 0.02)
+		else:# No low pass filter but if enforced
+			if enforced_to_H1: new_avg = filt_tanl(new_avg, FH1, 0.02)
+		if B_enhance: new_avg = fft(new_avg)
 			
-			if options.local_alignment:
-				if cpu_dict[im] == Blockdata["myid"]:
-					write_text_row(plist_dict[im], os.path.join(Tracker["constants"]["masterdir"], "ali2d_local_params_avg", "ali2d_local_params_avg_%03d.txt"%im))
+		new_avg.set_attr("members",   list_dict[iavg])
+		new_avg.set_attr("n_objects", len(list_dict[iavg]))
+		slist[iavg]    = new_avg
+		sxprint(strftime("%Y-%m-%d_%H:%M:%S", localtime()) + " =>",  "Refined average %7d"%iavg)
+		
+	## send to main node to write
+	mpi.mpi_barrier(mpi.MPI_COMM_WORLD)
+
+	
+	for im in range(navg):
+		# avg
+		if cpu_dict[im] == Blockdata["myid"] and Blockdata["myid"] != Blockdata["main_node"]:
+			send_EMData(slist[im], Blockdata["main_node"],  tag_sharpen_avg)
+		
+		elif cpu_dict[im] == Blockdata["myid"] and Blockdata["myid"] == Blockdata["main_node"]:
+			slist[im].set_attr("members", memlist[im])
+			slist[im].set_attr("n_objects", len(memlist[im]))
+			slist[im].write_image(os.path.join(Tracker["constants"]["masterdir"], "class_averages.hdf"), im)
+		
+		elif cpu_dict[im] != Blockdata["myid"] and Blockdata["myid"] == Blockdata["main_node"]:
+			new_avg_other_cpu = recv_EMData(cpu_dict[im], tag_sharpen_avg)
+			new_avg_other_cpu.set_attr("members", memlist[im])
+			new_avg_other_cpu.set_attr("n_objects", len(memlist[im]))
+			new_avg_other_cpu.write_image(os.path.join(Tracker["constants"]["masterdir"], "class_averages.hdf"), im)
+		
+		if options.local_alignment:
+			if cpu_dict[im] == Blockdata["myid"]:
+				write_text_row(plist_dict[im], os.path.join(Tracker["constants"]["masterdir"], "ali2d_local_params_avg", "ali2d_local_params_avg_%03d.txt"%im))
+			
+			if cpu_dict[im] == Blockdata["myid"] and cpu_dict[im]!= Blockdata["main_node"]:
+				wrap_mpi_send(plist_dict[im], Blockdata["main_node"], mpi.MPI_COMM_WORLD)
+				wrap_mpi_send(FH_list, Blockdata["main_node"], mpi.MPI_COMM_WORLD)
+			
+			elif cpu_dict[im]!= Blockdata["main_node"] and Blockdata["myid"] == Blockdata["main_node"]:
+				dummy = wrap_mpi_recv(cpu_dict[im], mpi.MPI_COMM_WORLD)
+				plist_dict[im] = dummy
+				dummy = wrap_mpi_recv(cpu_dict[im], mpi.MPI_COMM_WORLD)
+				FH_list[im] = dummy[im]
+		else:
+			if cpu_dict[im] == Blockdata["myid"] and cpu_dict[im]!= Blockdata["main_node"]:
+				wrap_mpi_send(FH_list, Blockdata["main_node"], mpi.MPI_COMM_WORLD)
+			
+			elif cpu_dict[im]!= Blockdata["main_node"] and Blockdata["myid"] == Blockdata["main_node"]:
+				dummy = wrap_mpi_recv(cpu_dict[im], mpi.MPI_COMM_WORLD)
+				FH_list[im] = dummy[im]
 				
-				if cpu_dict[im] == Blockdata["myid"] and cpu_dict[im]!= Blockdata["main_node"]:
-					wrap_mpi_send(plist_dict[im], Blockdata["main_node"], MPI_COMM_WORLD)
-					wrap_mpi_send(FH_list, Blockdata["main_node"], MPI_COMM_WORLD)
-				
-				elif cpu_dict[im]!= Blockdata["main_node"] and Blockdata["myid"] == Blockdata["main_node"]:
-					dummy = wrap_mpi_recv(cpu_dict[im], MPI_COMM_WORLD)
-					plist_dict[im] = dummy
-					dummy = wrap_mpi_recv(cpu_dict[im], MPI_COMM_WORLD)
-					FH_list[im] = dummy[im]
-			else:
-				if cpu_dict[im] == Blockdata["myid"] and cpu_dict[im]!= Blockdata["main_node"]:
-					wrap_mpi_send(FH_list, Blockdata["main_node"], MPI_COMM_WORLD)
-				
-				elif cpu_dict[im]!= Blockdata["main_node"] and Blockdata["myid"] == Blockdata["main_node"]:
-					dummy = wrap_mpi_recv(cpu_dict[im], MPI_COMM_WORLD)
-					FH_list[im] = dummy[im]
-					
-			mpi_barrier(MPI_COMM_WORLD)
-		mpi_barrier(MPI_COMM_WORLD)
+		mpi.mpi_barrier(mpi.MPI_COMM_WORLD)
+	mpi.mpi_barrier(mpi.MPI_COMM_WORLD)
 	
 	if options.local_alignment:
 		if Blockdata["myid"] == Blockdata["main_node"]:
@@ -522,7 +517,7 @@ def main():
 		if Blockdata["myid"] == Blockdata["main_node"]:
 			write_text_row(FH_list, os.path.join(Tracker["constants"]["masterdir"], "FH_list.txt"))
 				
-	mpi_barrier(MPI_COMM_WORLD)			
+	mpi.mpi_barrier(mpi.MPI_COMM_WORLD)			
 	target_xr =3
 	target_yr =3
 	if( Blockdata["myid"] == 0):

--- a/sparx/bin/sxcompute_isac_avg.py
+++ b/sparx/bin/sxcompute_isac_avg.py
@@ -447,7 +447,7 @@ def main():
 
 		elif no_adjustment: pass
 		
-		if Tracker["constants"]["low_pass_filter"] != -1.0:di
+		if Tracker["constants"]["low_pass_filter"] != -1.0:
 			if Tracker["constants"]["low_pass_filter"] == 0.0: low_pass_filter = FH1
 			elif Tracker["constants"]["low_pass_filter"] == 1.0: 
 				low_pass_filter = FH2

--- a/sparx/bin/sxcopyfromtif.py
+++ b/sparx/bin/sxcopyfromtif.py
@@ -43,6 +43,8 @@ import os
 
 import mpi
 
+mpi.mpi_init( 0, [] )
+
 
 def main():
 	progname = os.path.basename(sys.argv[0])
@@ -81,8 +83,7 @@ def main():
 			disable_bdb_cache()
 
 		if options.MPI:
-			sys.argv = mpi.mpi_init(len(sys.argv),sys.argv)
-			global mpi_rank
+			global mpi_rank # there is no global variable called mpi_rank (or any other, for that matter)
 			mpi_rank = mpi.mpi_comm_rank( mpi.MPI_COMM_WORLD )
 
 
@@ -96,5 +97,4 @@ if __name__ == "__main__":
 	global_def.print_timestamp( "Start" )
 	main()
 	global_def.print_timestamp( "Finish" )
-	if "OMPI_COMM_WORLD_SIZE" in os.environ:
-		mpi.mpi_finalize()
+	mpi.mpi_finalize()

--- a/sparx/bin/sxcpy.py
+++ b/sparx/bin/sxcpy.py
@@ -46,6 +46,7 @@ from global_def import *
 from optparse import OptionParser
 import sys
 
+
 def main():
 	progname = os.path.basename(sys.argv[0])
 	usage = progname + " stack_in  stack_out"

--- a/sparx/bin/sxcter.py
+++ b/sparx/bin/sxcter.py
@@ -45,6 +45,8 @@ from     utilities  import if_error_then_all_processes_exit_program
 from mpi import mpi_init, mpi_comm_rank, mpi_comm_size, mpi_barrier, MPI_COMM_WORLD
 import mpi
 
+mpi.mpi_init( 0, [] )
+
 global_def.BATCH = True
 
 
@@ -131,9 +133,8 @@ Stack Mode - Process a particle stack (Not supported by SPHIRE GUI))::
 
 	main_mpi_proc = 0
 	if RUNNING_UNDER_MPI:
-		sys.argv = mpi_init(len(sys.argv), sys.argv)
-		my_mpi_proc_id = mpi_comm_rank(MPI_COMM_WORLD)
-		n_mpi_procs = mpi_comm_size(MPI_COMM_WORLD)
+		my_mpi_proc_id = mpi.mpi_comm_rank(MPI_COMM_WORLD)
+		n_mpi_procs    = mpi.mpi_comm_size(MPI_COMM_WORLD)
 		global_def.MPI = True
 
 	else:

--- a/sparx/bin/sxfactcoords.py
+++ b/sparx/bin/sxfactcoords.py
@@ -12,6 +12,8 @@ import os
 import sys
 
 import mpi
+
+mpi.mpi_init( 0, [] )
       
 def main():
 	progname = os.path.basename(sys.argv[0])
@@ -46,9 +48,6 @@ def main():
 			from utilities import disable_bdb_cache
 			disable_bdb_cache()
 
-		if options.MPI:
-			sys.argv = mpi.mpi_init(len(sys.argv), sys.argv)
-
 		from utilities import get_im
 		global_def.BATCH = True
 		
@@ -65,5 +64,4 @@ if __name__ == "__main__":
 	global_def.print_timestamp( "Start" )
 	main()
 	global_def.print_timestamp( "Finish" )
-	if "OMPI_COMM_WORLD_SIZE" in os.environ:
-		mpi.mpi_finalize()
+	mpi.mpi_finalize()

--- a/sparx/bin/sxfilrecons3d.py
+++ b/sparx/bin/sxfilrecons3d.py
@@ -42,6 +42,9 @@ import sys
 
 import mpi
 
+mpi.mpi_init( 0, [] )
+
+
 def main():
 	arglist = []
 	for arg in sys.argv:
@@ -71,9 +74,7 @@ def main():
 		return
 	
 	else:
-		if options.MPI:
-			sys.argv = mpi.mpi_init(len(sys.argv), sys.argv)
-		else:
+		if not options.MPI:
 			ERROR( "There is only MPI version of sxfilrecons3d.py. See SPARX wiki page for downloading MyMPI details." )
 			return
 			
@@ -93,5 +94,4 @@ if __name__ == "__main__":
 	global_def.print_timestamp( "Start" )
 	main()
 	global_def.print_timestamp( "Finish" )
-	if "OMPI_COMM_WORLD_SIZE" in os.environ:
-		mpi.mpi_finalize()
+	mpi.mpi_finalize()

--- a/sparx/bin/sxfilterlocal.py
+++ b/sparx/bin/sxfilterlocal.py
@@ -46,6 +46,8 @@ from global_def import SPARX_MPI_TAG_UNIVERSAL
 
 import mpi
 
+mpi.mpi_init( 0, [] )
+
 def main():
 	arglist = []
 	for arg in sys.argv:
@@ -73,7 +75,6 @@ def main():
 		disable_bdb_cache()
 
 	if options.MPI:
-		sys.argv = mpi.mpi_init(len(sys.argv),sys.argv)		
 		number_of_proc = mpi.mpi_comm_size(MPI_COMM_WORLD)
 		myid = mpi.mpi_comm_rank(MPI_COMM_WORLD)
 		main_node = 0
@@ -170,5 +171,4 @@ if __name__ == "__main__":
 	global_def.print_timestamp( "Start" )
 	main()
 	global_def.print_timestamp( "Finish" )
-	if "OMPI_COMM_WORLD_SIZE" in os.environ:
-		mpi.mpi_finalize()
+	mpi.mpi_finalize()

--- a/sparx/bin/sxfind_struct.py
+++ b/sparx/bin/sxfind_struct.py
@@ -43,6 +43,8 @@ from   optparse   import OptionParser
 import sys
 import mpi
 
+mpi.mpi_init( 0, [] )
+
 def main():
 	progname = os.path.basename(sys.argv[0])
 	usage    = progname + " stack outdir --ir --ou --delta --dpsi --lf --hf --rand_seed --maxit --debug --noweights --trials --given --first_zero --weights --MPIGA--pcross --pmut --maxgen --MPI --trials"
@@ -95,7 +97,6 @@ def main():
 			global_def.BATCH = False
 
 		elif options.MPI:
-			sys.argv = mpi.mpi_init(len(sys.argv),sys.argv)
 
 			from applications import cml_find_structure_MPI2
 			global_def.BATCH = True
@@ -117,5 +118,4 @@ if __name__ == "__main__":
 	global_def.print_timestamp( "Start" )
 	main()
 	global_def.print_timestamp( "Finish" )
-	if "OMPI_COMM_WORLD_SIZE" in os.environ:
-		mpi.mpi_finalize()
+	mpi.mpi_finalize()

--- a/sparx/bin/sxhelicon.py
+++ b/sparx/bin/sxhelicon.py
@@ -40,6 +40,9 @@ from global_def import sxprint, ERROR
 
 import mpi
 
+mpi.mpi_init( 0, [] )
+
+
 def main():
 	arglist = []
 	for arg in sys.argv:
@@ -117,16 +120,9 @@ def main():
 			ERROR( "ywobble has to be smaller than dp/2" )
 			return
 
-		try:
-			sys.argv = mpi.mpi_init(len(sys.argv), sys.argv)
-		except:
-			ERROR( "This program has only MPI version.  Please install MPI library." )
-			return
-
 		if global_def.CACHE_DISABLE:
 			from utilities import disable_bdb_cache
 			disable_bdb_cache()
-
 
 		if len(args) < 4:
 			mask = None

--- a/sparx/bin/sxhelicon_utils.py
+++ b/sparx/bin/sxhelicon_utils.py
@@ -43,6 +43,8 @@ from builtins import range
 
 import mpi
 
+mpi.mpi_init( 0, [] )
+
 
 def main():
 	arglist = []
@@ -251,9 +253,6 @@ def main():
 		nearbyp = int( (options.nearby/options.apix) + 0.5)
 		zstepp = int( (options.zstep/options.apix) + 0.5)
 
-		if options.MPI:
-			sys.argv = mpi.mpi_init(len(sys.argv), sys.argv)
-
 		if len(options.predict_helical) > 0:
 			
 			if len(args) != 1:
@@ -436,5 +435,4 @@ if __name__ == "__main__":
 	global_def.print_timestamp( "Start" )
 	main()
 	global_def.print_timestamp( "Finish" )
-	if "OMPI_COMM_WORLD_SIZE" in os.environ:
-		mpi.mpi_finalize()
+	mpi.mpi_finalize()

--- a/sparx/bin/sxheliconlocal.py
+++ b/sparx/bin/sxheliconlocal.py
@@ -43,6 +43,9 @@ from builtins import range
 
 import mpi
 
+mpi.mpi_init( 0, [] )
+
+
 def main():
 	arglist = []
 	for arg in sys.argv:
@@ -134,8 +137,6 @@ def main():
 		# now y_restrict has the same format as x search range .... has to change ihrsr accordingly
 		for i in range(len(y_restrict)): y_restrict2 +=  str(float(y_restrict[i])/options.apix)+" "
 		y_restrict2 = y_restrict2[:-1]
-
-		sys.argv = mpi.mpi_init(len(sys.argv), sys.argv)
 
 		if global_def.CACHE_DISABLE:
 			from utilities import disable_bdb_cache

--- a/sparx/bin/sxihrsr.py
+++ b/sparx/bin/sxihrsr.py
@@ -43,6 +43,8 @@ from builtins import range
 
 import mpi
 
+mpi.mpi_init( 0, [] )
+
 def main():
 	arglist = []
 	for arg in sys.argv:
@@ -125,9 +127,6 @@ def main():
 		for i in range(len(y_restrict)):
 			y_restrict2 += " "+str(float(y_restrict[i])/options.apix)
 
-		if options.MPI:
-			sys.argv = mpi.mpi_init( len(sys.argv), sys.argv )
-
 		if global_def.CACHE_DISABLE:
 			from utilities import disable_bdb_cache
 			disable_bdb_cache()
@@ -144,5 +143,4 @@ if __name__ == "__main__":
 	global_def.print_timestamp( "Start" )
 	main()
 	global_def.print_timestamp( "Finish" )
-	if "OMPI_COMM_WORLD_SIZE" in os.environ:
-		mpi.mpi_finalize()
+	mpi.mpi_finalize()

--- a/sparx/bin/sxk_means.py
+++ b/sparx/bin/sxk_means.py
@@ -45,7 +45,7 @@ import mpi
 
 #
 #
-# NOTE: this does not invoke mpi.mpi_init(); the mpi version probably does not work b/c of that
+# NOTE: this never invoke mpi.mpi_init(); the mpi version probably does not work b/c of that
 #
 #
 

--- a/sparx/bin/sxk_means_stable.py
+++ b/sparx/bin/sxk_means_stable.py
@@ -43,6 +43,9 @@ import sys
 
 import mpi
 
+mpi.mpi_init( 0, [] )
+
+
 def main():
 	
 	progname = os.path.basename(sys.argv[0])
@@ -68,8 +71,10 @@ def main():
 		ERROR( "Invalid number of parameters used. Please see usage information above." )
 		return
 	else:
-		if len(args) == 2: mask = None
-		else:              mask = args[2]
+		if len(args) == 2:
+			mask = None
+		else:
+			mask = args[2]
 
 		if options.K < 2:
 			ERROR( "K must be > 1 group" )
@@ -85,19 +90,9 @@ def main():
 
 		global_def.BATCH = True
 		if options.MPI:
-			sys.argv = mpi.mpi_init(len(sys.argv), sys.argv)
-			'''if options.CUDA:
-				from  development import  k_means_stab_MPICUDA_stream_YANG
-				k_means_stab_MPICUDA_stream_YANG(args[0], args[1], mask, options.K, options.nb_part, options.F, options.T0, options.th_nobj, options.rand_seed, options.maxit)
-			else:'''
 			from  statistics import  k_means_stab_MPI_stream
 			k_means_stab_MPI_stream(args[0], args[1], mask, options.K, options.nb_part, 0.0, 0.0, options.th_nobj, options.rand_seed, "SSE", options.CTF, options.maxit)
 		else:
-			'''if options.CUDA:
-				from  development  import  k_means_stab_CUDA_stream
-				k_means_stab_CUDA_stream(args[0], args[1], mask, options.K, options.nb_part, options.F, options.T0, options.th_nobj, options.rand_seed, options.maxit)
-			else:'''
-			
 			from  statistics  import  k_means_stab_stream
 			k_means_stab_stream(args[0], args[1], mask, options.K, options.nb_part, 0.0, 0.0, options.th_nobj, options.rand_seed, "SSE", options.CTF, options.maxit)
 		global_def.BATCH = False
@@ -107,5 +102,4 @@ if __name__ == "__main__":
 	global_def.print_timestamp( "Start" )
 	main()
 	global_def.print_timestamp( "Finish" )
-	if "OMPI_COMM_WORLD_SIZE" in os.environ:
-		mpi.mpi_finalize()
+	mpi.mpi_finalize()

--- a/sparx/bin/sxlocal_ali3d.py
+++ b/sparx/bin/sxlocal_ali3d.py
@@ -42,6 +42,9 @@ import sys
 
 import mpi
 
+mpi.mpi_init( 0, [] )
+
+
 def main():
 	arglist = []
 	for arg in sys.argv:
@@ -78,9 +81,6 @@ def main():
 		else:
 			mask = args[2]
 
-		if options.MPI:
-			sys.argv = mpi.mpi_init(len(sys.argv), sys.argv)
-
 		if global_def.CACHE_DISABLE:
 			from utilities import disable_bdb_cache
 			disable_bdb_cache()
@@ -110,5 +110,4 @@ if __name__ == "__main__":
 	global_def.print_timestamp( "Start" )
 	main()
 	global_def.print_timestamp( "Finish" )
-	if "OMPI_COMM_WORLD_SIZE" in os.environ:
-		mpi.mpi_finalize()
+	mpi.mpi_finalize()

--- a/sparx/bin/sxlocal_ali3dm.py
+++ b/sparx/bin/sxlocal_ali3dm.py
@@ -44,6 +44,9 @@ import sys
 
 import mpi
 
+mpi.mpi_init( 0, [] )
+
+
 def main():
 	arglist = []
 	for arg in sys.argv:
@@ -81,9 +84,6 @@ def main():
 		else:
 			mask = args[3]
 
-		if(options.MPI):
-			sys.argv = mpi.mpi_init( len(sys.argv), sys.argv )
-
 		if global_def.CACHE_DISABLE:
 			from utilities import disable_bdb_cache
 			disable_bdb_cache()
@@ -101,5 +101,4 @@ if __name__ == "__main__":
 	global_def.print_timestamp( "Start" )
 	main()
 	global_def.print_timestamp( "Finish" )
-	if "OMPI_COMM_WORLD_SIZE" in os.environ:
-		mpi.mpi_finalize()
+	mpi.mpi_finalize()

--- a/sparx/bin/sxlocres.py
+++ b/sparx/bin/sxlocres.py
@@ -46,6 +46,9 @@ import utilities
 
 from global_def import sxprint, ERROR
 
+mpi.mpi_init( 0, [] )
+
+
 #Transforms the local resolution file from frequency units to angstroms.
 def makeAngRes(freqvol, nx, ny, nz, pxSize, freq_to_real=True):
 	if (pxSize == 1.0):
@@ -137,7 +140,6 @@ def main():
 	res_overall = options.res_overall
 
 	if options.MPI:
-		sys.argv = mpi.mpi_init(len(sys.argv),sys.argv)		
 
 		number_of_proc = mpi.mpi_comm_size(mpi.MPI_COMM_WORLD)
 		myid = mpi.mpi_comm_rank(mpi.MPI_COMM_WORLD)
@@ -271,5 +273,4 @@ if __name__ == "__main__":
 	global_def.print_timestamp( "Start" )
 	main()
 	global_def.print_timestamp( "Finish" )
-	if "OMPI_COMM_WORLD_SIZE" in os.environ:
-		mpi.mpi_finalize()
+	mpi.mpi_finalize()

--- a/sparx/bin/sxmeridien.py
+++ b/sparx/bin/sxmeridien.py
@@ -120,8 +120,8 @@ from   time import localtime, strftime, sleep, time
 global Tracker, Blockdata
 global  target_theta, refang
 
-
 mpi.mpi_init(0, [])
+
 Tracker   = {}
 Blockdata = {}
 #  MPI stuff

--- a/sparx/bin/sxmref_ali2d.py
+++ b/sparx/bin/sxmref_ali2d.py
@@ -42,6 +42,9 @@ import sys
 
 import mpi
 
+mpi.mpi_init( 0, [] )
+
+
 def main():
 	arglist = []
 	for arg in sys.argv:
@@ -82,9 +85,6 @@ def main():
 			from utilities import disable_bdb_cache
 			disable_bdb_cache()
 		
-		if options.MPI:
-			sys.argv = mpi.mpi_init(len(sys.argv), sys.argv)
-
 		global_def.BATCH = True
 		if options.EQ:
 			from development import mrefeq_ali2df
@@ -101,5 +101,4 @@ if __name__ == "__main__":
 	global_def.print_timestamp( "Start" )
 	main()
 	global_def.print_timestamp( "Finish" )
-	if "OMPI_COMM_WORLD_SIZE" in os.environ:
-		mpi.mpi_finalize()
+	mpi.mpi_finalize()

--- a/sparx/bin/sxmref_ali3d.py
+++ b/sparx/bin/sxmref_ali3d.py
@@ -43,6 +43,9 @@ import sys
 
 import mpi
 
+mpi.mpi_init( 0, [] )
+
+
 def main():
 	arglist = []
 	i = 0
@@ -106,13 +109,14 @@ def main():
 		
 		global_def.BATCH = True
 		if options.MPI:
-			sys.argv = mpi.mpi_init(len(sys.argv),sys.argv)
+
 			if options.kmeans:
 				from applications import Kmref_ali3d_MPI
 				Kmref_ali3d_MPI(args[0], args[1], args[2], maskfile, options.focus, options.maxit, options.ir, options.ou, options.rs, \
 				options.xr, options.yr, options.ts, options.delta, options.an, options.center, \
 				options.nassign, options.nrefine, options.CTF, options.snr, options.ref_a, options.sym, \
 				options.function,  options.npad, options.debug, options.fourvar, options.stoprnct, mpi_comm=None, log=None)
+
 			elif options.kmeans2:
 				if( options.nassign != 0):
 					sxprint("  Setting nassign to zero")
@@ -122,6 +126,7 @@ def main():
 				options.xr, options.yr, options.ts, options.delta, options.an, options.center, \
 				options.nassign, options.nrefine, options.CTF, options.snr, options.ref_a, options.sym, \
 				options.function,  options.npad, options.debug, options.fourvar, options.stoprnct, mpi_comm=None, log=None)
+
 			else:
 				from applications import mref_ali3d_MPI
 				mref_ali3d_MPI(args[0], args[1], args[2], maskfile, options.focus, options.maxit, options.ir, options.ou, options.rs, \
@@ -129,6 +134,7 @@ def main():
 				options.nassign, options.nrefine, options.CTF, options.snr, options.ref_a, options.sym, \
 				options.function,  options.npad, options.debug, options.fourvar, options.stoprnct, mpi_comm = None, log = None)
 		else:
+
 			from applications import mref_ali3d
 			mref_ali3d(args[0], args[1], args[2], maskfile, options.focus, options.maxit, options.ir, options.ou, options.rs, 
 			options.xr, options.yr, options.ts, options.delta, options.an, options.center,
@@ -141,5 +147,4 @@ if __name__ == "__main__":
 	global_def.print_timestamp( "Start" )
 	main()
 	global_def.print_timestamp( "Finish" )
-	if "OMPI_COMM_WORLD_SIZE" in os.environ:
-		mpi.mpi_finalize()
+	mpi.mpi_finalize()

--- a/sparx/bin/sxmref_alignment.py
+++ b/sparx/bin/sxmref_alignment.py
@@ -43,6 +43,9 @@ from   optparse       import OptionParser
 
 import mpi
 
+mpi.mpi_init( 0, [] )
+
+
 def main():
 	progname = os.path.basename(sys.argv[0])
 	usage = progname + " out_averages outdir --ou=outer_radius --xr=x_range --ts=translation_step --maxit=max_iteration --CTF --snr=SNR --function=user_function_name --Fourvar --th_err=threshold_cutoff --ali=kind_of_alignment --center=center_type"
@@ -75,9 +78,6 @@ def main():
 			from utilities import disable_bdb_cache
 			disable_bdb_cache()
 
-		if options.MPI:
-			sys.argv = mpi.mpi_init(len(sys.argv),sys.argv)		
-
 		global_def.BATCH = True
 		from development import mref_alignment
 		mref_alignment(args[0], args[1], args[2], options.ou, options.xr, options.ts, options.maxit, options.function, options.snr, options.CTF, 
@@ -89,5 +89,4 @@ if __name__ == "__main__":
 	global_def.print_timestamp( "Start" )
 	main()
 	global_def.print_timestamp( "Finish" )
-	if "OMPI_COMM_WORLD_SIZE" in os.environ:
-		mpi.mpi_finalize()
+	mpi.mpi_finalize()

--- a/sparx/bin/sxmulti_ali2d.py
+++ b/sparx/bin/sxmulti_ali2d.py
@@ -43,6 +43,9 @@ import sys
 
 import mpi
 
+mpi.mpi_init( 0, [] )
+
+
 def main():
 	progname = os.path.basename(sys.argv[0])
 	usage = progname + " stack outdir <maskfile> --ir=inner_radius --ou=outer_radius --rs=ring_step --xr=x_range --yr=y_range --ts=translation_step --dst=delta --center=center --maxit=max_iteration --CTF --snr=SNR --Fourvar=Fourier_variance --Ng=group_number --Function=user_function_name --CUDA --GPUID --MPI"
@@ -91,9 +94,6 @@ def main():
 			from utilities import disable_bdb_cache
 			disable_bdb_cache()
 		
-		if options.MPI:
-			sys.argv = mpi.mpi_init(len(sys.argv),sys.argv)
-
 		global_def.BATCH = True
 		multi_ali2d(args[0], outdir, mask, options.ir, options.ou, options.rs, options.xr, options.yr, options.ts, options.dst, options.center, \
 			options.maxit, options.CTF, options.snr, options.Fourvar, options.Ng, options.num_ali, options.function, options.CUDA, options.GPUID, options.MPI)
@@ -104,5 +104,4 @@ if __name__ == "__main__":
 	global_def.print_timestamp( "Start" )
 	main()
 	global_def.print_timestamp( "Finish" )
-	if "OMPI_COMM_WORLD_SIZE" in os.environ:
-		mpi.mpi_finalize()
+	mpi.mpi_finalize()

--- a/sparx/bin/sxmulti_assign.py
+++ b/sparx/bin/sxmulti_assign.py
@@ -43,6 +43,9 @@ import sys, configparser
 
 import mpi
 
+mpi.mpi_init( 0, [] )
+
+
 def main():
 	progname = os.path.basename(sys.argv[0])
 	usage = progname + " configure_file.cfg"
@@ -78,9 +81,6 @@ def main():
 		from utilities import disable_bdb_cache
 		disable_bdb_cache()
 
-	if options.MPI:
-		sys.argv = mpi.mpi_init(len(sys.argv),sys.argv)		
-		
 	from development import multi_assign
 	global_def.BATCH = True
 	multi_assign(args[0], args[1], args[2], mask, options.ir, options.ou, options.rs, options.xr, options.yr, options.ts,  
@@ -92,5 +92,4 @@ if __name__ == "__main__":
 	global_def.print_timestamp( "Start" )
 	main()
 	global_def.print_timestamp( "Finish" )
-	if "OMPI_COMM_WORLD_SIZE" in os.environ:
-		mpi.mpi_finalize()
+	mpi.mpi_finalize()

--- a/sparx/bin/sxpca.py
+++ b/sparx/bin/sxpca.py
@@ -42,6 +42,9 @@ import os
 import sys
 import mpi
 
+mpi.mpi_init( 0, [] )
+
+
       
 def main():
 	progname = os.path.basename(sys.argv[0])
@@ -67,7 +70,6 @@ def main():
 
 	isRoot = True
 	if options.MPI:
-		sys.argv = mpi.mpi_init( len(sys.argv), sys.argv )
 		isRoot = ( mpi.mpi_comm_rank(mpi.MPI_COMM_WORLD) == 0 )
 		
 	if global_def.CACHE_DISABLE:
@@ -90,5 +92,5 @@ if __name__ == "__main__":
 	global_def.print_timestamp( "Start" )
 	main()
 	global_def.print_timestamp( "Finish" )
-	if "OMPI_COMM_WORLD_SIZE" in os.environ:
-		mpi.mpi_finalize()
+	mpi.mpi_finalize()
+	

--- a/sparx/bin/sxplot_projs_distrib.py
+++ b/sparx/bin/sxplot_projs_distrib.py
@@ -29,9 +29,6 @@ from __future__ import print_function
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
-#
-#
-
 
 import os
 import global_def
@@ -40,6 +37,8 @@ from global_def import sxprint, ERROR
 from   global_def import *
 from   optparse import OptionParser
 import sys
+
+
 def main():
 	
 	progname = os.path.basename(sys.argv[0])

--- a/sparx/bin/sxprepare_2d_forPCA.py
+++ b/sparx/bin/sxprepare_2d_forPCA.py
@@ -38,6 +38,8 @@ from global_def import sxprint, ERROR
 from   global_def import *
 from   optparse import OptionParser
 import sys
+
+
 def main():
 	progname = os.path.basename(sys.argv[0])
 	usage = progname + " input_stack output_stack average --avg --CTF"

--- a/sparx/bin/sxproj_stability.py
+++ b/sparx/bin/sxproj_stability.py
@@ -74,6 +74,9 @@ from utilities    import send_EMData, recv_EMData
 from utilities    import get_image, bcast_number_to_all, set_params2D, get_params2D
 from utilities    import group_proj_by_phitheta, model_circle, get_input_from_string
 
+mpi.mpi_init( 0, [] )
+
+
 def main():
 
 	progname = os.path.basename(sys.argv[0])
@@ -97,8 +100,6 @@ def main():
 
 	(options,args) = parser.parse_args()
 	
-
-	sys.argv = mpi.mpi_init(len(sys.argv), sys.argv)
 	myid = mpi.mpi_comm_rank(MPI_COMM_WORLD)
 	number_of_proc = mpi.mpi_comm_size(MPI_COMM_WORLD)
 	main_node = 0

--- a/sparx/bin/sxrealignment.py
+++ b/sparx/bin/sxrealignment.py
@@ -42,6 +42,9 @@ from   optparse       import OptionParser
 
 import mpi
 
+mpi.mpi_init( 0, [] )
+
+
 def main():
 	progname = os.path.basename(sys.argv[0])
 	usage = progname + " out_averages outdir --ou=outer_radius --xr=x_range --ts=translation_step --maxit=max_iteration --CTF --snr=SNR --function=user_function_name --Fourvar --ali=kind_of_alignment --center=center_type"
@@ -79,9 +82,6 @@ def main():
 			from utilities import disable_bdb_cache
 			disable_bdb_cache()
 
-		if options.MPI:
-			sys.argv = mpi.mpi_init(len(sys.argv),sys.argv)
-
 		global_def.BATCH = True
 		if options.old:
 			from development import realid
@@ -96,5 +96,4 @@ if __name__ == "__main__":
 	global_def.print_timestamp( "Start" )
 	main()
 	global_def.print_timestamp( "Finish" )
-	if "OMPI_COMM_WORLD_SIZE" in os.environ:
-		mpi.mpi_finalize()
+	mpi.mpi_finalize()

--- a/sparx/bin/sxrecons3d_f.py
+++ b/sparx/bin/sxrecons3d_f.py
@@ -41,6 +41,9 @@ from   utilities import get_image
 
 import mpi
 
+mpi.mpi_init( 0, [] )
+
+
 def main():
 
 	arglist = []
@@ -75,9 +78,6 @@ def main():
 	else:
 		mask = get_image( args[3] )
 
-	if options.MPI:
-		sys.argv = mpi.mpi_init(len(sys.argv), sys.argv)
-		
 	if global_def.CACHE_DISABLE:
 		from utilities import disable_bdb_cache
 		disable_bdb_cache()
@@ -97,5 +97,4 @@ if __name__ == "__main__":
 	global_def.print_timestamp( "Start" )
 	main()
 	global_def.print_timestamp( "Finish" )
-	if "OMPI_COMM_WORLD_SIZE" in os.environ:
-		mpi.mpi_finalize()
+	mpi.mpi_finalize()

--- a/sparx/bin/sxrecons3d_n.py
+++ b/sparx/bin/sxrecons3d_n.py
@@ -43,6 +43,9 @@ import os
 import sys
 import mpi
 
+mpi.mpi_init( 0, [] )
+
+
 def main():
 	arglist = []
 	for arg in sys.argv:
@@ -71,9 +74,6 @@ def main():
 	parser.add_option("--target_window_size",               type="int",           default=-1,     help=" size of the targeted reconstruction ")
 
 	(options,args) = parser.parse_args(arglist[1:])
-
-	if options.MPI:
-		sys.argv = mpi.mpi_init(len(sys.argv), sys.argv)
 
 	if global_def.CACHE_DISABLE:
 		from utilities import disable_bdb_cache
@@ -123,5 +123,4 @@ if __name__=="__main__":
 	global_def.print_timestamp( "Start" )
 	main()
 	global_def.print_timestamp( "Finish" )
-	if "OMPI_COMM_WORLD_SIZE" in os.environ:
-		mpi.mpi_finalize()
+	mpi.mpi_finalize()

--- a/sparx/bin/sxresample.py
+++ b/sparx/bin/sxresample.py
@@ -44,6 +44,9 @@ from   optparse import OptionParser
 
 import mpi
 
+mpi.mpi_init( 0, [] )
+
+
 def resample_insert( bufprefix, fftvols, wgtvols, mults, CTF, npad, info=None):
 	from EMAN2 import  newfile_store
 	ostore = newfile_store( bufprefix, npad, CTF )
@@ -299,9 +302,6 @@ def main():
 	prjfile = args[0]
 
 	if options.MPI:
-		from mpi import mpi_comm_rank, mpi_comm_size, MPI_COMM_WORLD
-		from mpi import mpi_init
-		sys.argv = mpi.mpi_init( len(sys.argv), sys.argv )
 		myid = mpi.mpi_comm_rank( mpi.MPI_COMM_WORLD )
 		ncpu = mpi.mpi_comm_size( mpi.MPI_COMM_WORLD )
 	else:
@@ -323,5 +323,4 @@ if __name__ == "__main__":
 	global_def.print_timestamp( "Start" )
 	main()
 	global_def.print_timestamp( "Finish" )
-	if "OMPI_COMM_WORLD_SIZE" in os.environ:
-		mpi.mpi_finalize()
+	mpi.mpi_finalize()

--- a/sparx/bin/sxrewindow.py
+++ b/sparx/bin/sxrewindow.py
@@ -48,6 +48,9 @@ from global_def import *
 
 import mpi
 
+mpi.mpi_init( 0, [] )
+
+
 # ========================================================================================
 # General Helper Functions
 # ========================================================================================
@@ -210,12 +213,11 @@ For negative staining data, use --skip_invert.
 	
 	main_mpi_proc = 0
 	if RUNNING_UNDER_MPI:
-		mpi.mpi_init(0, [])
 		my_mpi_proc_id = mpi.mpi_comm_rank( mpi.MPI_COMM_WORLD )
-		n_mpi_procs = mpi.mpi_comm_size( mpi.MPI_COMM_WORLD )
+		n_mpi_procs    = mpi.mpi_comm_size( mpi.MPI_COMM_WORLD )
 	else:
 		my_mpi_proc_id = 0
-		n_mpi_procs = 1
+		n_mpi_procs    = 1
 	
 	# ------------------------------------------------------------------------------------
 	# Set up SPHIRE global definitions
@@ -1370,8 +1372,7 @@ if __name__=="__main__":
 	global_def.print_timestamp( "Start" )
 	main()
 	global_def.print_timestamp( "Finish" )
-	if "OMPI_COMM_WORLD_SIZE" in os.environ:
-		mpi.mpi_finalize()
+	mpi.mpi_finalize()
 
 # ========================================================================================
 #  END OF FILE

--- a/sparx/bin/sxrsort3d.py
+++ b/sparx/bin/sxrsort3d.py
@@ -19,6 +19,9 @@ from    morphology  import 	get_shrink_3dmask
 
 import mpi
 
+mpi.mpi_init( 0, [] )
+
+
 # utilities
 from utilities      import get_im,bcast_number_to_all,cmdexecute,write_text_file,read_text_file,wrap_mpi_bcast
 from applications   import recons3d_n_MPI, mref_ali3d_MPI, Kmref_ali3d_MPI
@@ -97,7 +100,6 @@ def main():
 		global_def.BATCH = True
 
 		#---initialize MPI related variables
-		sys.argv  = mpi.mpi_init(len(sys.argv),sys.argv)
 		nproc     = mpi.mpi_comm_size( mpi.MPI_COMM_WORLD )
 		myid      = mpi.mpi_comm_rank( mpi.MPI_COMM_WORLD )
 		mpi_comm  = mpi.MPI_COMM_WORLD

--- a/sparx/bin/sxrviper.py
+++ b/sparx/bin/sxrviper.py
@@ -23,6 +23,9 @@ from EMAN2 import EMData
 
 import mpi
 
+mpi.mpi_init( 0, [] )
+
+
 
 MAXIMUM_NO_OF_VIPER_RUNS_ANALYZED_TOGETHER = 10
 # NORMALIZED_AREA_THRESHOLD_FOR_OUTLIER_DETECTION = 0.2
@@ -560,10 +563,9 @@ def get_already_processed_viper_runs(run_get_already_processed_viper_runs):
 def main():
 
 	main_node = 0
-	mpi.mpi_init(0, [])
-	mpi_comm = mpi.MPI_COMM_WORLD
-	myid = mpi.mpi_comm_rank(mpi.MPI_COMM_WORLD)
-	mpi_size = mpi.mpi_comm_size(mpi.MPI_COMM_WORLD)	# Total number of processes, passed by --np option.
+	mpi_comm  = mpi.MPI_COMM_WORLD
+	myid      = mpi.mpi_comm_rank(mpi.MPI_COMM_WORLD)
+	mpi_size  = mpi.mpi_comm_size(mpi.MPI_COMM_WORLD)	# Total number of processes, passed by --np option.
 
 	progname = os.path.basename(sys.argv[0])
 	usage = progname + " stack  [output_directory] --ir=inner_radius --radius=outer_radius --rs=ring_step --xr=x_range --yr=y_range  --ts=translational_search_step  --delta=angular_step --an=angular_neighborhood  --center=center_type --maxit1=max_iter1 --maxit2=max_iter2 --L2threshold=0.1  --fl --aa --ref_a=S --sym=c1"

--- a/sparx/bin/sxshiftali.py
+++ b/sparx/bin/sxshiftali.py
@@ -63,6 +63,9 @@ from pixel_error  import ordersegments
 
 import mpi
 
+mpi.mpi_init( 0, [] )
+
+
 #
 # NOTE: there are still more imports strewn throughout the code below
 #
@@ -102,8 +105,6 @@ def main():
 			from utilities import disable_bdb_cache
 			disable_bdb_cache()
 		
-		sys.argv = mpi.mpi_init(len(sys.argv),sys.argv)
-
 		global_def.BATCH = True
 		if options.oneDx:
 			helicalshiftali_MPI(args[0], mask, options.maxit, options.CTF, options.snr, options.Fourvar, options.search_rng)		

--- a/sparx/bin/sxsort3d.py
+++ b/sparx/bin/sxsort3d.py
@@ -21,6 +21,9 @@ from   logger     import Logger, BaseLogger_Files
 
 import mpi
 
+mpi.mpi_init( 0, [] )
+
+
 
 def main():
 	from logger import Logger, BaseLogger_Files
@@ -90,7 +93,6 @@ def main():
 		masterdir                       =args[1]
 		global_def.BATCH = True
 		#---initialize MPI related variables
-		sys.argv = mpi.mpi_init(len(sys.argv),sys.argv)
 		nproc    = mpi.mpi_comm_size(mpi.MPI_COMM_WORLD)
 		myid     = mpi.mpi_comm_rank(mpi.MPI_COMM_WORLD)
 		mpi_comm = mpi.MPI_COMM_WORLD

--- a/sparx/bin/sxsort3d_depth.py
+++ b/sparx/bin/sxsort3d_depth.py
@@ -78,7 +78,6 @@ global  Tracker, Blockdata
 
 import mpi
 
-
 mpi.mpi_init(0, [])
 nproc     = mpi.mpi_comm_size( mpi.MPI_COMM_WORLD )
 myid      = mpi.mpi_comm_rank( mpi.MPI_COMM_WORLD )

--- a/sparx/bin/sxsort3d_new.py
+++ b/sparx/bin/sxsort3d_new.py
@@ -38,6 +38,7 @@ import mpi
 mpi_init(0, [])
 nproc     = mpi_comm_size(MPI_COMM_WORLD)
 myid      = mpi_comm_rank(MPI_COMM_WORLD)
+
 Blockdata = {}
 #  MPI stuff
 Blockdata["nproc"]              = nproc

--- a/sparx/bin/sxssnr3d.py
+++ b/sparx/bin/sxssnr3d.py
@@ -41,6 +41,9 @@ import sys
 
 import mpi
 
+mpi.mpi_init( 0, [] )
+
+
 def main():
 	arglist = []
 	for arg in sys.argv: arglist.append( arg )
@@ -92,9 +95,6 @@ def main():
 			reference = args[3]
 			mask      = args[4]
 
-		if options.MPI:
-			sys.argv = mpi.mpi_init(len(sys.argv), sys.argv)
-
 		if global_def.CACHE_DISABLE:
 			from utilities import disable_bdb_cache
 			disable_bdb_cache()
@@ -109,5 +109,4 @@ if __name__ == "__main__":
 	global_def.print_timestamp( "Start" )
 	main()
 	global_def.print_timestamp( "Finish" )
-	if "OMPI_COMM_WORLD_SIZE" in os.environ:
-		mpi.mpi_finalize()
+	mpi.mpi_finalize()

--- a/sparx/bin/sxunblur.py
+++ b/sparx/bin/sxunblur.py
@@ -38,6 +38,8 @@ import applications
 import utilities
 import mpi
 
+mpi.mpi_init( 0, [] )
+
 
 def parse_args():
 	"""
@@ -290,10 +292,9 @@ def main(args):
 	None
 	"""
 
-	mpi.mpi_init(0, [])
-	main_mpi_proc = 0
+	main_mpi_proc  = 0
 	my_mpi_proc_id = mpi.mpi_comm_rank(mpi.MPI_COMM_WORLD)
-	n_mpi_procs = mpi.mpi_comm_size(mpi.MPI_COMM_WORLD)
+	n_mpi_procs    = mpi.mpi_comm_size(mpi.MPI_COMM_WORLD)
 
 	# Import the file names
 	sanity_checks(args, my_mpi_proc_id)

--- a/sparx/bin/sxvar.py
+++ b/sparx/bin/sxvar.py
@@ -41,6 +41,9 @@ from global_def import *
 
 import mpi
 
+mpi.mpi_init( 0, [] )
+
+
 def main():
 	from   optparse       import OptionParser
 	progname = os.path.basename(sys.argv[0])
@@ -71,9 +74,8 @@ def main():
 		if global_def.CACHE_DISABLE:
 			from utilities import disable_bdb_cache
 			disable_bdb_cache()
-		if options.MPI:
-			sys.argv = mpi.mpi_init( len(sys.argv), sys.argv )
 
+		if options.MPI:
 
 			arglist = []
 			for arg in sys.argv:
@@ -101,5 +103,4 @@ if __name__ == "__main__":
 	global_def.print_timestamp( "Start" )
 	main()
 	global_def.print_timestamp( "Finish" )
-	if "OMPI_COMM_WORLD_SIZE" in os.environ:
-		mpi.mpi_finalize()
+	mpi.mpi_finalize()

--- a/sparx/bin/sxviper.py
+++ b/sparx/bin/sxviper.py
@@ -22,6 +22,9 @@ from multi_shc import multi_shc
 
 import mpi
 
+mpi.mpi_init( 0, [] )
+
+
 def main(args):
 
 	progname = os.path.basename(sys.argv[0])
@@ -102,8 +105,6 @@ directory		output directory name: into which the results will be written (if it 
 		sxprint("Please run \'" + progname + " -h\' for detailed options" )
 		ERROR( "Invalid number of parameters used. Please see usage information above." )
 		return
-
-	mpi.mpi_init(0, [])
 
 	log = Logger(BaseLogger_Files())
 

--- a/sparx/libpy/global_def.py
+++ b/sparx/libpy/global_def.py
@@ -152,8 +152,8 @@ def print_timestamp( tag="" ):
 		mpi_rank = int( os.environ['OMPI_COMM_WORLD_RANK'] )
 
 		# printing the "Start"-tag will sync up the log file names so that all processes use the same logfile
+		global SXPRINT_LOG, SXPRINT_LOG_SYNC
 		if not SXPRINT_LOG_SYNC and "start" in tag.lower():
-			global SXPRINT_LOG, SXPRINT_LOG_SYNC
 			SXPRINT_LOG = util.send_string_to_all( SXPRINT_LOG, 0 )
 			SXPRINT_LOG_SYNC = True
 

--- a/sparx/libpy/morphology.py
+++ b/sparx/libpy/morphology.py
@@ -2203,13 +2203,11 @@ def cter_mrk(input_image_path, output_directory, selection_list = None, wn = 512
 							print(warinnig_message)
 						print("    Ignores this as an invalid entry.")
 					else:
-						# print("MRK_DEBUG: adding mic_id_substr := ", mic_id_substr)
 						valid_mic_id_substr_list.append(mic_id_substr)
-				# 	# This entry is not in the selection list. Do nothing
+				# otherwise: this entry is not in the selection list; do nothing
 			
 			# Check the input dataset consistency and save the result to a text file, if necessary.
 			if check_consistency:
-				# Create output directory
 				os.mkdir(output_directory)
 			
 				# Open the consistency check file
@@ -2259,14 +2257,7 @@ def cter_mrk(input_image_path, output_directory, selection_list = None, wn = 512
 			print(("  Entries in selection list   : %6d" % (len(selected_mic_path_list))))
 			print(("  Rejected by no input        : %6d" % (len(no_input_mic_id_substr_list))))
 			print(("  Valid Entries               : %6d" % (len(valid_mic_id_substr_list))))
-			
-			# --------------------------------------------------------------------------------
-			# Check MPI error condition
-			# --------------------------------------------------------------------------------
-			if len(valid_mic_id_substr_list) < n_mpi_procs:
-				error_status = ("Number of MPI processes (%d) supplied by --np in mpirun cannot be greater than %d (number of valid s that satisfy all criteria to be processed). Run %s -h for help." % (n_mpi_procs, len(valid_mic_id_substr_list, program_name)), getframeinfo(currentframe()))
-				break
-			
+					
 			# --------------------------------------------------------------------------------
 			# Create input file path list
 			# --------------------------------------------------------------------------------
@@ -2297,11 +2288,8 @@ def cter_mrk(input_image_path, output_directory, selection_list = None, wn = 512
 		# --------------------------------------------------------------------------------
 		# Print all error messages and abort the process if necessary.
 		# --------------------------------------------------------------------------------
-		# NOTE: Toshio Moriya 2016/11/15
-		# The following function takes care of the case when an if-statement uses break for occurence of an error.
-		# However, more elegant way is to use 'exception' statement of exception mechanism...
-		# 
-		if_error_then_all_processes_exit_program(error_status)
+
+		if_error_then_all_processes_exit_program(error_status) # this should be throwing an exception
 		
 	else:
 		input_file_path_list.append(input_image_path)
@@ -2357,7 +2345,7 @@ def cter_mrk(input_image_path, output_directory, selection_list = None, wn = 512
 	# Set up loop variables depending on the cter mode
 	if stack == None:
 		if RUNNING_UNDER_MPI:
-			set_start, set_end = MPI_start_end(len(namics), n_mpi_procs, my_mpi_proc_id)
+			set_start, set_end = MPI_start_end( len(namics), n_mpi_procs, my_mpi_proc_id )
 		else:
 			set_start = 0
 			set_end = len(namics)
@@ -3314,14 +3302,7 @@ def cter_pap(input_image_path, output_directory, selection_list = None, wn = 512
 			print(("  Entries in selection list   : %6d" % (len(selected_mic_path_list))))
 			print(("  Rejected by no input        : %6d" % (len(no_input_mic_id_substr_list))))
 			print(("  Valid Entries               : %6d" % (len(valid_mic_id_substr_list))))
-			
-			# --------------------------------------------------------------------------------
-			# Check MPI error condition
-			# --------------------------------------------------------------------------------
-			if len(valid_mic_id_substr_list) < n_mpi_procs:
-				error_status = ("Number of MPI processes (%d) supplied by --np in mpirun cannot be greater than %d (number of valid s that satisfy all criteria to be processed). Run %s -h for help." % (n_mpi_procs, len(valid_mic_id_substr_list, program_name)), getframeinfo(currentframe()))
-				break
-			
+					
 			# --------------------------------------------------------------------------------
 			# Create input file path list
 			# --------------------------------------------------------------------------------
@@ -5701,14 +5682,7 @@ def cter_vpp(input_image_path, output_directory, selection_list = None, wn = 512
 			print(("  Entries in selection list   : %6d" % (len(selected_mic_path_list))))
 			print(("  Rejected by no input        : %6d" % (len(no_input_mic_id_substr_list))))
 			print(("  Valid Entries               : %6d" % (len(valid_mic_id_substr_list))))
-			
-			# --------------------------------------------------------------------------------
-			# Check MPI error condition
-			# --------------------------------------------------------------------------------
-			if len(valid_mic_id_substr_list) < n_mpi_procs:
-				error_status = ("Number of MPI processes (%d) supplied by --np in mpirun cannot be greater than %d (number of valid s that satisfy all criteria to be processed). Run %s -h for help." % (n_mpi_procs, len(valid_mic_id_substr_list, program_name)), getframeinfo(currentframe()))
-				break
-			
+					
 			# --------------------------------------------------------------------------------
 			# Create input file path list
 			# --------------------------------------------------------------------------------

--- a/sparx/libpy/utilities.py
+++ b/sparx/libpy/utilities.py
@@ -58,6 +58,7 @@ import morphology
 
 # MPI imports (NOTE: import mpi after EMAN2)
 from applications import MPI_start_end
+import mpi
 from mpi import mpi_comm_size, mpi_bcast, MPI_FLOAT, MPI_COMM_WORLD
 from mpi import mpi_recv, mpi_send, mpi_barrier
 
@@ -3801,16 +3802,12 @@ def gather_EMData(data, number_of_proc, myid, main_node):
 
 
 def send_string_to_all(str_to_send, source_node=0):
-	from mpi import MPI_COMM_WORLD, MPI_INT, MPI_CHAR, mpi_bcast, mpi_comm_rank
-
-	myid = mpi_comm_rank(MPI_COMM_WORLD)
+	myid = mpi.mpi_comm_rank(mpi.MPI_COMM_WORLD)
+	
 	str_to_send_len = len(str_to_send) * int(myid == source_node)
-	str_to_send_len = mpi_bcast(
-		str_to_send_len, 1, MPI_INT, source_node, MPI_COMM_WORLD
-	)[0]
-	str_to_send = mpi_bcast(
-		str_to_send, str_to_send_len, MPI_CHAR, source_node, MPI_COMM_WORLD
-	)
+	str_to_send_len = mpi.mpi_bcast( str_to_send_len, 1, mpi.MPI_INT, source_node, mpi.MPI_COMM_WORLD )[0]
+	str_to_send     = mpi.mpi_bcast( str_to_send, str_to_send_len, mpi.MPI_CHAR, source_node, mpi.MPI_COMM_WORLD )
+
 	return "".join(str_to_send)
 
 
@@ -3818,23 +3815,22 @@ def bcast_number_to_all(number_to_send, source_node=0, mpi_comm=-1):
 	"""
 		number_to_send has to be pre-defined in each node
 	"""
-	from mpi import mpi_bcast, MPI_INT, MPI_COMM_WORLD, MPI_FLOAT
 	import types
 
 	if mpi_comm == -1:
-		mpi_comm = MPI_COMM_WORLD
+		mpi_comm = mpi.MPI_COMM_WORLD
 	if type(number_to_send) is int:
-		TMP = mpi_bcast(number_to_send, 1, MPI_INT, source_node, mpi_comm)
+		TMP = mpi.mpi_bcast(number_to_send, 1, mpi.MPI_INT, source_node, mpi_comm)
 		return int(TMP[0])
 	elif type(number_to_send) is float:
-		TMP = mpi_bcast(number_to_send, 1, MPI_FLOAT, source_node, mpi_comm)
+		TMP = mpi.mpi_bcast(number_to_send, 1, mpi.MPI_FLOAT, source_node, mpi_comm)
 		return float(TMP[0])
 	elif type(number_to_send) is bool:
 		if number_to_send:
 			number_to_send = 1
 		else:
 			number_to_send = 0
-		TMP = mpi_bcast(number_to_send, 1, MPI_INT, source_node, mpi_comm)
+		TMP = mpi.mpi_bcast(number_to_send, 1, mpi.MPI_INT, source_node, mpi_comm)
 		if TMP == 1:
 			return True
 		else:


### PR DESCRIPTION
* Removed faulty abort criterion in `sxcompute_isac_avg-py`.
* **FIX:** When using mpi different processes would create different logfiles. Now when printing the "Start"-tagged timestamp we synchronize logile name across mpi process (only when using mpi).