### PR TITLE
added BILD for RVIPER refvol and copies best avg/var to toplevel dir

### DIFF
--- a/sphire/bin/sp_rviper.py
+++ b/sphire/bin/sp_rviper.py
@@ -25,6 +25,7 @@ from argparse import Namespace
 
 import mpi
 from sp_applications import cpy
+from shutil import copyfile
 
 mpi.mpi_init( 0, [] )
 
@@ -43,6 +44,8 @@ NAME_OF_RUN_DIR = "run"
 NAME_OF_MAIN_DIR = "main"
 NAME_OF_PARAMS_FILE = "rotated_reduced_params.txt"
 DIR_DELIM = os.sep
+AVG_VOL_FILE = "average_volume.hdf"
+VAR_VOL_FILE = "variance_volume.hdf"
 
 def calculate_list_of_independent_viper_run_indices_used_for_outlier_elimination(no_of_viper_runs_analyzed_together, 
 	no_of_viper_runs_analyzed_together_from_user_options, masterdir, rviper_iter, criterion_name, symc, runs_iter):
@@ -533,8 +536,8 @@ def calculate_volumes_after_rotation_and_save_them(ali3d_options, rviper_iter, m
 			if(st[0] > goal):  goal = st[0]
 			else:  going = False
 		# over and out
-		asa.write_image(mainoutputdir + DIR_DELIM + "average_volume.hdf")
-		sas.write_image(mainoutputdir + DIR_DELIM + "variance_volume.hdf")
+		asa.write_image(os.path.join(mainoutputdir, AVG_VOL_FILE) )
+		sas.write_image(os.path.join(mainoutputdir, VAR_VOL_FILE) )
 	return
 
 
@@ -939,6 +942,13 @@ output_directory: directory name into which the output files will be written.  I
 		if increment_for_current_iteration == MUST_END_PROGRAM_THIS_ITERATION:
 			if (myid == main_node):
 				sxprint("RVIPER found a core set of stable projections for the current RVIPER iteration (%d), the maximum angle difference between corresponding projections from different VIPER volumes is less than %.2f. Finishing."%(rviper_iter, ANGLE_ERROR_THRESHOLD))
+				iter_avg = masterdir + DIR_DELIM + NAME_OF_MAIN_DIR + "%03d"%(rviper_iter) + DIR_DELIM + AVG_VOL_FILE  
+				iter_var = masterdir + DIR_DELIM + NAME_OF_MAIN_DIR + "%03d"%(rviper_iter) + DIR_DELIM + VAR_VOL_FILE  
+				master_avg = os.path.join(masterdir, "average_volume_%03d.hdf" % rviper_iter)
+				master_var = os.path.join(masterdir, "variance_volume_%03d.hdf" % rviper_iter)
+				sxprint('Copying average and variance from iteration %03d to output directory %s' % (rviper_iter, masterdir) )
+				copyfile(iter_avg, master_avg) 
+				copyfile(iter_var, master_var) 
 			break
 	else:
 		if (myid == main_node):

--- a/sphire/libpy/sp_multi_shc.py
+++ b/sphire/libpy/sp_multi_shc.py
@@ -227,18 +227,12 @@ def ali3d_multishc(stack, ref_vol, ali3d_options, symmetry_class, mpi_comm = Non
 	L2threshold = ali3d_options.L2threshold
 
 	# Optionally restrict out-of-plane angle
-	####try: theta1 = ali3d_options.theta1
-	####except AttributeError: theta1 = -1.0
 	if hasattr(ali3d_options, 'theta1'): theta1 = ali3d_options.theta1
 	else: theta1 = -1.0
 	
-	####try: theta2 = ali3d_options.theta2
-	####except AttributeError: theta2 = -1.0
 	if hasattr(ali3d_options, 'theta2'): theta2 = ali3d_options.theta2
 	else: theta2 = -1.0
 	
-	####try: method = ali3d_options.method
-	####except AttributeError: method = "S"
 	if hasattr(ali3d_options, 'method'): method = ali3d_options.method
 	else: method = "S"
 	
@@ -888,18 +882,12 @@ def ali3d_multishc_2(stack, ref_vol, ali3d_options, symmetry_class, mpi_comm = N
 	ref_a  = ali3d_options.ref_a
 
 	# Optionally restrict out-of-plane angle
-	####try: theta1 = ali3d_options.theta1
-	####except AttributeError: theta1 = -1.0
 	if hasattr(ali3d_options, 'theta1'): theta1 = ali3d_options.theta1
 	else: theta1 = -1.0
 	
-	####try: theta2 = ali3d_options.theta2
-	####except AttributeError: theta2 = -1.0
 	if hasattr(ali3d_options, 'theta2'): theta2 = ali3d_options.theta2
 	else: theta2 = -1.0
 	
-	####try: method = ali3d_options.method
-	####except AttributeError: method = "S"
 	if hasattr(ali3d_options, 'method'): method = ali3d_options.method
 	else: method = "S"
 	
@@ -1496,6 +1484,27 @@ def multi_shc(all_projs, subset, runs_count, ali3d_options, mpi_comm, log=None, 
 		L2 = ref_vol.cmp("dot", ref_vol, dict(negative = 0, mask = model_circle(ali3d_options.ou, nx,nx,nx)))
 		log.add(" L2 norm of reference volume:  %f"%L2)
 
+		# Generate angular distribution
+		if hasattr(ali3d_options, 'dpi'):
+			dpi = ali3d_options.dpi
+		else:
+			dpi = 72
+		pixel_size = 1  # Not going to upscale to the original dimensions, so in Chimera open reconstruction at 1 Angstrom/voxel, etc.
+		
+		angular_distribution(
+			params_file=log.prefix+'refparams2.txt',
+			output_folder=log.prefix,
+			prefix='refvol2_angdist',
+			method=method,
+			pixel_size=pixel_size,
+			delta=float(ali3d_options.delta),
+			symmetry=ali3d_options.sym,
+			box_size=nx,
+			particle_radius=ali3d_options.ou,
+			dpi=dpi,
+			do_print=False,
+			)
+		
 	"""
 	if mpi_rank == 17:
 		temp = []
@@ -1535,13 +1544,9 @@ def multi_shc(all_projs, subset, runs_count, ali3d_options, mpi_comm, log=None, 
 		independent_run_dir = log.prefix
 		sp_global_def.sxprint('independent_run_dir', independent_run_dir)
 		
-		####params_file = log.prefix + "params.txt"
-		####write_text_row(rotated_params[i1], params_file)  # 5 columns
-		
 		params_file = log.prefix + "params.txt"
 		output_folder = independent_run_dir 
-		prefix = 'angdist'  # will overwrite input parameters file if blank
-		####method = ali3d_options.ref_a  # method for generating the quasi-uniformly distributed projection directions
+		prefix = 'volf_angdist'  # will overwrite input parameters file if blank
 		delta = float(ali3d_options.delta)
 		symmetry = ali3d_options.sym
 		if hasattr(ali3d_options, 'dpi'):
@@ -1551,7 +1556,6 @@ def multi_shc(all_projs, subset, runs_count, ali3d_options, mpi_comm, log=None, 
 		
 		# Not going to upscale to the original dimensions, so in Chimera open reconstruction at 1 Angstrom/voxel, etc.
 		pixel_size = 1
-		####particle_radius = ali3d_options.radius
 		box_size = get_im( os.path.join(log.prefix, 'volf.hdf') ).get_xsize()
 		
 		angular_distribution(


### PR DESCRIPTION
1) The starting refvol2 sometimes looks nicer than the refined volf.hdf, so now the angular distribution is written for both.

2) The "best" average & variance are buried in the main00# directories, so it is now copied to the top-level output directory, with the iteration number in the name.
