### PR TITLE
Free memory of data_array

### DIFF
--- a/libpyEM/typeconverter.cpp
+++ b/libpyEM/typeconverter.cpp
@@ -143,12 +143,14 @@ EMData* EMNumPy::numpy2em(const python::numeric::array& array)
 		void* array_data = PyArray_DATA(array_ptr);
 		memcpy(temparray, array_data, (size_t)nx*ny*nz*sizeof(float));
 		image = new EMData((float*)temparray, nx, ny, nz);
+		free(array_data);
 	}
 	else {
 		PyArrayObject * array_ptr2 = (PyArrayObject*) PyArray_Cast(array_ptr, NPY_FLOAT32); //
 		void* array_data2 = PyArray_DATA(array_ptr2);
 		memcpy(temparray, array_data2, (size_t)nx*ny*nz*sizeof(float));
 		image = new EMData((float*)temparray, nx, ny, nz);
+		free(array_data2);
 	}
 
 	image->update();


### PR DESCRIPTION
The current function numpy2em results in a memory leak that builds up over time if used a lot.

Freeing the pointer array_data/array_data2 seems to fix this issue.

Script to reproduce (it is actually a python script):
[memory_leak_numpy2em.txt](https://github.com/cryoem/eman2/files/3184384/memory_leak_numpy2em.txt)
