### PR TITLE
Change naming convention for e2proc2/3d.py

### DIFF
--- a/programs/e2proc2d.py
+++ b/programs/e2proc2d.py
@@ -1093,7 +1093,7 @@ def main():
 							d.write_image(outfile, 0, out_type, False, region, out_mode, not_swap)
 
 						elif options.unstacking:	# output a series numbered single image files
-							out_name = outfile.split('.')[0]+'-'+str(i+1).zfill(len(str(nimg)))+'.'+outfile.split('.')[-1]
+							out_name = os.path.splitext(outfile)[0]+'-'+str(i+1).zfill(len(str(nimg)))+os.path.splitext(outfile)[-1]
 							if d["sigma"]==0:
 								if options.verbose > 0:
 									print("Warning: sigma = 0 for image ",i)

--- a/programs/e2proc3d.py
+++ b/programs/e2proc3d.py
@@ -748,7 +748,7 @@ def main():
 				print("rescale output to range {} - {}".format(data["render_min"],data["render_max"]))
 
 		if options.unstacking:	#output a series numbered single image files
-			data.write_image(outfile.split('.')[0]+'-'+str(img_index+1).zfill(len(str(nimg)))+ '.' + outfile.split('.')[-1], -1, EMUtil.ImageType.IMAGE_UNKNOWN, False, None, file_mode_map[options.outmode], not(options.swap))
+			data.write_image(os.path.splitext(outfile)[0]+'-'+str(img_index+1).zfill(len(str(nimg)))+ os.path.splitext(outfile)[-1], -1, EMUtil.ImageType.IMAGE_UNKNOWN, False, None, file_mode_map[options.outmode], not(options.swap))
 		else:   #output a single 2D image or a 2D stack
 			if options.append:
 				data.write_image(outfile, -1, EMUtil.get_image_ext_type(options.outtype), False, None, file_mode_map[options.outmode], not(options.swap))


### PR DESCRIPTION
I had multiple times the problem, that the unstacking of e2proc2d.py was not using the FILE_NAME-NUMBER.EXTENSION pattern correctly.
The previous implementation did not assume any dots present in the complete file_path.

Here, I propose a fix to this issue that utilizes os.path.splitext to make sure that the number goes between file_name and file_extension.