### PR TITLE
Fix reference vs value errors in libpyTransform2

### DIFF
--- a/libpyEM/libpyTransform2.cpp
+++ b/libpyEM/libpyTransform2.cpp
@@ -214,7 +214,6 @@ BOOST_PYTHON_MODULE(libpyTransform2)
 		.staticmethod("get")
 		;
 	typedef void (EMAN::Vec4f::*vec4f_set_value_at_float)(int, const float&);
-	typedef void (EMAN::Vec4f::*vec4f_set_value_float)(const float&, const float&, const float&, const float&);
 	typedef float (EMAN::Vec4f::*vec4f_at_float)(int) const;	
 	class_< EMAN::Vec4f >("Vec4f", "typedef Vec4<float> Vec4f;", init<  >())
 		.def(init< float, float, float, float >())
@@ -225,7 +224,7 @@ BOOST_PYTHON_MODULE(libpyTransform2)
 		.def("length", &EMAN::Vec4f::length)
 		.def("set_value", (void (EMAN::Vec4f::*)(const std::vector<float,std::allocator<float> >&) )&EMAN::Vec4f::set_value)
 		.def("set_value_at", vec4f_set_value_at_float(&EMAN::Vec4f::set_value_at))
-		.def("set_value", (void (EMAN::Vec4f::*)(float, float, float, float) )vec4f_set_value_float(&EMAN::Vec4f::set_value))
+		.def("set_value", (void (EMAN::Vec4f::*)(const float&, const float&, const float&, const float&) )&EMAN::Vec4f::set_value)
 	.def("at", vec4f_at_float(&EMAN::Vec4f::at))
 	.def("__getitem__",vec4f_at_float(&EMAN::Vec4f::at))
 		.def("__setitem__",vec4f_set_value_at_float(&EMAN::Vec4f::set_value_at))
@@ -235,7 +234,6 @@ BOOST_PYTHON_MODULE(libpyTransform2)
 	typedef float (EMAN::Vec3f::*dot_float)(const EMAN::Vec3f&) const;
 	typedef EMAN::Vec3f (EMAN::Vec3f::*cross_float)(const EMAN::Vec3f&) const;
 	typedef void (EMAN::Vec3f::*set_value_at_float)(int, const float&);
-	typedef void (EMAN::Vec3f::*set_value_float)(const float&, const float&,const float&);
 	typedef float (EMAN::Vec3f::*at_float)(int) const;
 	
     class_< EMAN::Vec3f >("Vec3f", "typedef Vec3<float> Vec3f;", init<  >())
@@ -251,7 +249,7 @@ BOOST_PYTHON_MODULE(libpyTransform2)
         .def("as_list", &EMAN::Vec3f::as_list)
         .def("set_value", (void (EMAN::Vec3f::*)(const std::vector<float,std::allocator<float> >&) )&EMAN::Vec3f::set_value)
 		.def("set_value_at", set_value_at_float(&EMAN::Vec3f::set_value_at))
-		.def("set_value", (void (EMAN::Vec3f::*)(float, float, float) )set_value_float(&EMAN::Vec3f::set_value))
+		.def("set_value", (void (EMAN::Vec3f::*)(const float&, const float&, const float&) )&EMAN::Vec3f::set_value)
         .def("at", at_float(&EMAN::Vec3f::at))
         .def("__getitem__",at_float(&EMAN::Vec3f::at))
 		.def("__setitem__",set_value_at_float(&EMAN::Vec3f::set_value_at))
@@ -289,7 +287,6 @@ BOOST_PYTHON_MODULE(libpyTransform2)
 	typedef int (EMAN::Vec3i::*dot_int)(const EMAN::Vec3i&) const;
 	typedef EMAN::Vec3i (EMAN::Vec3i::*cross_int)(const EMAN::Vec3i&) const;
 	typedef void (EMAN::Vec3i::*set_value_at_int)(int, const int&);
-	typedef void (EMAN::Vec3i::*set_value_int)(const int&, const int&,const int&);
 	typedef int (EMAN::Vec3i::*at_int)(int) const;
     class_< EMAN::Vec3i >("Vec3i", "typedef Vec3<int> Vec3i;", init<  >())
         .def(init< int, int,  int  >())
@@ -302,7 +299,7 @@ BOOST_PYTHON_MODULE(libpyTransform2)
         .def("as_list", &EMAN::Vec3i::as_list)
         .def("set_value", (void (EMAN::Vec3i::*)(const std::vector<int,std::allocator<int> >&) )&EMAN::Vec3i::set_value)
 		.def("set_value_at",set_value_at_int( &EMAN::Vec3i::set_value_at))
-        .def("set_value", (void (EMAN::Vec3i::*)(int, int, int) ) set_value_int(&EMAN::Vec3i::set_value))
+        .def("set_value", (void (EMAN::Vec3i::*)(const int&, const int&, const int&) ) &EMAN::Vec3i::set_value)
 		.def("at", at_int(&EMAN::Vec3i::at))
 		.def("__getitem__",at_int(&EMAN::Vec3i::at))
 		.def("__setitem__",set_value_at_int(&EMAN::Vec3i::set_value_at))
@@ -336,7 +333,6 @@ BOOST_PYTHON_MODULE(libpyTransform2)
 
 	typedef float (EMAN::Vec2f::*vec2f_dot_float)(const EMAN::Vec2f&) const;
 	typedef void (EMAN::Vec2f::*vec2f_set_value_at_float)(int, const float&);
-	typedef void (EMAN::Vec2f::*vec2f_set_value_float)(const float&, const float&);
 	typedef float (EMAN::Vec2f::*vec2f_at_float)(int) const;
 	class_< EMAN::Vec2f >("Vec2f", "typedef Vec2<float> Vec2f;", init<  >())
 		.def(init< float, float >())
@@ -349,7 +345,7 @@ BOOST_PYTHON_MODULE(libpyTransform2)
 		.def("as_list", &EMAN::Vec2f::as_list)
 		.def("set_value", (void (EMAN::Vec2f::*)(const std::vector<float,std::allocator<float> >&) )&EMAN::Vec2f::set_value)
 		.def("set_value_at", vec2f_set_value_at_float(&EMAN::Vec2f::set_value_at))
-		.def("set_value", (void (EMAN::Vec2f::*)(float, float) )vec2f_set_value_float(&EMAN::Vec2f::set_value))
+		.def("set_value", (void (EMAN::Vec2f::*)(const float&, const float&) )&EMAN::Vec2f::set_value)
 		.def("at", vec2f_at_float(&EMAN::Vec2f::at))
 		.def("__getitem__",vec2f_at_float(&EMAN::Vec2f::at))
 		.def("__setitem__",vec2f_set_value_at_float(&EMAN::Vec2f::set_value_at))


### PR DESCRIPTION
The various vector classes for which libpyTransform2 provides python
wrappers each has a set_value() method that accepts new vector
components as separate const reference arguments. The Boost.Python
wrappers for those methods were casting them to to function types
that receive their parameters by value.  Naturally, the resulting
wrappers did not work correctly. Additionally, the wrappers were
inserting an unnecessary extra reference to each function, supported
by some otherwise unused typedefs.

This commit corrects the casts to match the functions and removes
the unnecessary typedefs and extra references.

Fixes #461