### PR TITLE
Fixed integer overflow in assign_groups()

### DIFF
--- a/libEM/sphire/util_sphire.cpp
+++ b/libEM/sphire/util_sphire.cpp
@@ -164,7 +164,7 @@ using std::sin;
 struct assign_groups_comparator {
 	const float * values;
 	bool operator() (int i,int j) { return (values[i] > values[j]); }
-	assign_groups_comparator(const fl  oat * v) : values(v) {}
+	assign_groups_comparator(const float *v) : values(v) {}
 };
 
 // utility function used in (GPU) ISAC

--- a/libEM/sphire/util_sphire.cpp
+++ b/libEM/sphire/util_sphire.cpp
@@ -178,7 +178,7 @@ vector<int> Util::sp_assign_groups(std::string matrix_address, int nref, int nim
 	int group, ima;
 
 	// allocate and sort vector of indices
-    size_t count = (size_t)nref * (size_t)nima; // danger: nref*nima will not fit into int
+	size_t count = (size_t)nref * (size_t)nima; // danger: nref*nima will not fit into int
 	std::vector<int> dd(count) ;
 	for (size_t i=0; i<count; i++){
 		dd[i] = i;

--- a/libEM/sphire/util_sphire.cpp
+++ b/libEM/sphire/util_sphire.cpp
@@ -160,6 +160,83 @@ using std::sin;
 /* real_t sin(real_t); */
 #endif
 
+vector<int> Util::sp_assign_groups(std::string matrix_address, int nref, int nima)
+{
+	// convert memory address sent as string to float pointer
+	const float * matrix;
+	size_t addr = 0;
+	for ( std::string::const_iterator i = matrix_address.begin();  i != matrix_address.end();  ++i ) {
+		int digit = *i - '0';
+		addr *= 10;
+		addr += digit;
+	}
+	matrix = reinterpret_cast<float*>(addr);
+
+	int kt = nref;
+	unsigned int maxasi = (unsigned int)(nima/nref);
+	vector< vector<int> > id_list(nref);
+	int group, ima;
+
+	// allocate and sort vector of indices
+    size_t count = (size_t)nref * (size_t)nima; // danger: nref*nima will not fit into int
+	std::vector<int> dd(count) ;
+	for (size_t i=0; i<count; i++){
+		dd[i] = i;
+	}
+
+	assign_groups_comparator comparator(matrix);
+	sort(dd.begin(), dd.end(), comparator);
+	
+	// main loop
+	size_t begin = 0;
+	std::vector<bool> del_row(nref, false);
+	std::vector<bool> del_column(nima, false);
+	while (kt > 0) {
+		bool flag = true;
+		while (flag) {
+			int l = dd[begin];
+			group = l/nima;
+			ima = l%nima;
+			if (del_column[ima] || del_row[group]
+				begin++;
+			else
+				flag = false;
+		}
+
+		id_list[group].push_back(ima);
+		if (kt > 1) {
+			if (id_list[group].size() < maxasi)
+				group = -1;
+			else
+				kt -= 1;
+		} else {
+			if (id_list[group].size() < maxasi+nima%nref)
+				group = -1;
+			else
+				kt -= 1;
+		}
+		del_column[ima] = true;
+		if (group != -1) {
+			del_row[group] = true;
+		}
+	}
+	
+	vector<int> id_list_1;
+
+	for (int iref=0; iref<nref; iref++){
+		for (unsigned int im=0; im<maxasi; im++){
+			id_list_1.push_back(id_list[iref][im]);
+		}
+	}
+	for (unsigned int im=maxasi; im<maxasi+nima%nref; im++){
+		id_list_1.push_back(id_list[group][im]);
+	}
+
+	id_list_1.push_back(group);
+
+	return id_list_1;
+}
+
 vector<float> Util::pw_extract_sphire(vector<float>pw, int n, int iswi, float ps)
 {
 	int k,m,n1,klmd,klm2d,nklmd,n2d,n_larg,l, n2;

--- a/libEM/sphire/util_sphire.cpp
+++ b/libEM/sphire/util_sphire.cpp
@@ -164,7 +164,7 @@ using std::sin;
 struct assign_groups_comparator {
 	const float * values;
 	bool operator() (int i,int j) { return (values[i] > values[j]); }
-	assign_groups_comparator(const float * v) : values(v) {}
+	assign_groups_comparator(const fl  oat * v) : values(v) {}
 };
 
 // utility function used in (GPU) ISAC
@@ -205,7 +205,7 @@ vector<int> Util::sp_assign_groups(std::string matrix_address, int nref, int nim
 			int l = dd[begin];
 			group = l/nima;
 			ima = l%nima;
-			if (del_column[ima] || del_row[group]
+			if (del_column[ima] || del_row[group])
 				begin++;
 			else
 				flag = false;

--- a/libEM/sphire/util_sphire.cpp
+++ b/libEM/sphire/util_sphire.cpp
@@ -160,11 +160,11 @@ using std::sin;
 /* real_t sin(real_t); */
 #endif
 
-// utility struct for sp_assign_groups()
-struct assign_groups_comparator {
+// utility struct for sp_assign_groups() (unchanged from the original)
+struct sp_assign_groups_comparator {
 	const float * values;
 	bool operator() (int i,int j) { return (values[i] > values[j]); }
-	assign_groups_comparator(const float *v) : values(v) {}
+	sp_assign_groups_comparator(const float *v) : values(v) {}
 };
 
 // utility function used in (GPU) ISAC
@@ -192,7 +192,7 @@ vector<int> Util::sp_assign_groups(std::string matrix_address, int nref, int nim
 		dd[i] = i;
 	}
 
-	assign_groups_comparator comparator(matrix);
+	sp_assign_groups_comparator comparator(matrix);
 	sort(dd.begin(), dd.end(), comparator);
 	
 	// main loop

--- a/libEM/sphire/util_sphire.cpp
+++ b/libEM/sphire/util_sphire.cpp
@@ -160,6 +160,14 @@ using std::sin;
 /* real_t sin(real_t); */
 #endif
 
+// utility struct for sp_assign_groups()
+struct assign_groups_comparator {
+	const float * values;
+	bool operator() (int i,int j) { return (values[i] > values[j]); }
+	assign_groups_comparator(const float * v) : values(v) {}
+};
+
+// utility function used in (GPU) ISAC
 vector<int> Util::sp_assign_groups(std::string matrix_address, int nref, int nima)
 {
 	// convert memory address sent as string to float pointer

--- a/libEM/sphire/util_sphire.h
+++ b/libEM/sphire/util_sphire.h
@@ -35,6 +35,9 @@
 #ifndef util__sphire_h__
 #define util__sphire_h__
 
+// utility function used in (GPU) ISAC
+vector<int> Util::sp_assign_groups(std::string matrix_address, int nref, int nima)
+
 static vector<float> pw_extract_sphire(vector<float>pw, int n, int iswi,float ps);
 static vector<float> call_cl1_sphire(long int *k,long int *n, float *ps, long int *iswi, float *pw, float *q2, double *q, double *x, double *res, double *cu, double *s, long int *iu);
 static vector<float> lsfit_sphire(long int *ks,long int *n, long int *klm2d, long int *iswi, float *q1,double *q, double *x, double *res, double *cu, double *s,long int *iu);

--- a/libEM/sphire/util_sphire.h
+++ b/libEM/sphire/util_sphire.h
@@ -36,7 +36,7 @@
 #define util__sphire_h__
 
 // utility function used in (GPU) ISAC
-vector<int> Util::sp_assign_groups(std::string matrix_address, int nref, int nima)
+vector<int> Util::sp_assign_groups(std::string matrix_address, int nref, int nima);
 
 static vector<float> pw_extract_sphire(vector<float>pw, int n, int iswi,float ps);
 static vector<float> call_cl1_sphire(long int *k,long int *n, float *ps, long int *iswi, float *pw, float *q2, double *q, double *x, double *res, double *cu, double *s, long int *iu);

--- a/libEM/sphire/util_sphire.h
+++ b/libEM/sphire/util_sphire.h
@@ -36,7 +36,7 @@
 #define util__sphire_h__
 
 // utility function used in (GPU) ISAC
-vector<int> Util::sp_assign_groups(std::string matrix_address, int nref, int nima);
+static vector<int> sp_assign_groups(std::string matrix_address, int nref, int nima);
 
 static vector<float> pw_extract_sphire(vector<float>pw, int n, int iswi,float ps);
 static vector<float> call_cl1_sphire(long int *k,long int *n, float *ps, long int *iswi, float *pw, float *q2, double *q, double *x, double *res, double *cu, double *s, long int *iu);


### PR DESCRIPTION
Added `sp_assign_groups()` to `libEM/sphire/util_sphire.cpp` (fixes integer overflow issue in the original function).