### PR TITLE
Catch Attribute error of QDragEnterEvent

### DIFF
--- a/libpyEM/qtgui/emimage2d.py
+++ b/libpyEM/qtgui/emimage2d.py
@@ -1631,9 +1631,13 @@ class EMImage2DWidget(EMGLWidget):
 #		for i in f:
 #			print str(i)
 
-		if event.provides("application/x-eman"):
-			event.setDropAction(Qt.CopyAction)
-			event.accept()
+		try:
+			if event.provides("application/x-eman"):
+				event.setDropAction(Qt.CopyAction)
+				event.accept()
+		except AttributeError:
+			# 2020_10_09 Markus Stabrin: Happened after dragging a screenshot over the open image on MAC.
+			pass
 
 	def dropEvent(self,event):
 		if EMAN2.GUIbeingdragged:


### PR DESCRIPTION
What happened:

Taking a screenshot and dragging the screenshot inside the window led to an AttributeError on MAC:

- e2display.py
Traceback (most recent call last):
  File "/Users/stabrin/anaconda3/envs/sphire_1.4/lib/python3.7/site-packages/eman2_gui/emimage2d.py", line 1634, in dragEnterEvent
    if event.provides("application/x-eman"):
AttributeError: 'QDragEnterEvent' object has no attribute 'provides'