### PR TITLE
Png binary

### DIFF
--- a/libEM/io/pngio.cpp
+++ b/libEM/io/pngio.cpp
@@ -367,8 +367,10 @@ int PngIO::write_data(float *data, int image_index, const Region*,
 
 	if (depth_type == PNG_CHAR_DEPTH) {
 		renderbits = 8;
+	}
 	else if (depth_type == PNG_SHORT_DEPTH) {
 		renderbits = 16;
+	}
 	EMUtil::getRenderMinMax(data, nx, ny, rendermin, rendermax, renderbits);
 
 //	printf("render %f %f \n",rendermin,rendermax);

--- a/libEM/io/pngio.cpp
+++ b/libEM/io/pngio.cpp
@@ -365,6 +365,10 @@ int PngIO::write_data(float *data, int image_index, const Region*,
 	// If we didn't get any parameters in 'render_min' or 'render_max',
 	// we need to find some good ones
 
+	if (depth_type == PNG_CHAR_DEPTH) {
+		renderbits = 8;
+	else if (depth_type == PNG_SHORT_DEPTH) {
+		renderbits = 16;
 	EMUtil::getRenderMinMax(data, nx, ny, rendermin, rendermax, renderbits);
 
 //	printf("render %f %f \n",rendermin,rendermax);


### PR DESCRIPTION
Hello,

# Problem description

Using a "png" file extension leads to a binary image instead of a floating point image:

Output in v2.31:
![out](https://user-images.githubusercontent.com/18047816/96105826-c5419100-0eda-11eb-97d7-6cf8539f9956.png)

Output now:
![test1](https://user-images.githubusercontent.com/18047816/96106054-0639a580-0edb-11eb-95c3-dc61381ea326.png)

# Cause of the Problem

The renderbits variable is set to 0.  
Therefore, the getRenderMinMax function does not touch the values for rendermin and rendermax, which are 0 by default.

# Possible solution

Set the renderbits variable manually in the function

# Remarks

I think this solution is not optimal.  
It also looks like that the other io functions might be affected as well.  
However, in my quick look at the  I was not able to locate the optimal position in the code.  
@sludtke42 @shadowwalkersb Do you have an idea how to make this solution more generic?