### PR TITLE
Fix default boxsize for e2spt_tempmatch.py

### DIFF
--- a/programs/e2spt_tempmatch.py
+++ b/programs/e2spt_tempmatch.py
@@ -234,7 +234,7 @@ def main():
 		else:
 			bxs.extend([[p[2], p[1],p[0], 'tm', scr[i] ,kid] for i,p in enumerate(pts[:n]*nbin)])
 			if options.boxsz<0:
-				boxsz=sz*nbin
+				boxsz=int(ref["ny"]*mbin)
 			else:
 				boxsz=options.boxsz
 				


### PR DESCRIPTION
The variable sz is not defined and the program crashes ( issue https://github.com/cryoem/eman2/issues/546 ) . My pull request fixes this issue.
