### PR TITLE
e2helicalboxer.py default save to particles folder if in project directory

### DIFF
--- a/programs/e2helixboxer.py
+++ b/programs/e2helixboxer.py
@@ -62,7 +62,6 @@ within a helix. Usually, all particles from a micrograph will have the same dime
 
 E2HELIXBOXER_DB = "bdb:" # used to use "bdb:e2helixboxercache#"
 
-
 def main():
 	usage = """e2helixboxer.py --gui <micrograph1> <<micrograph2> <micrograph3> ...
 	e2helixboxer.py --gui --helix-width=<width> <micrograph1> <<micrograph2> <micrograph3> ...
@@ -688,7 +687,14 @@ if ENABLE_GUI:
 			(micrograph_dir, micrograph_filename) = os.path.split(micrograph_filepath)
 			self.micrograph_filename = micrograph_filename
 			self.micrograph_name = os.path.splitext(micrograph_filename)[0]
-			self.default_dir = os.getcwd()
+
+			#Check if in project dir. If so, default to particles directory. If not, default to cwd. Make particles directory in project dir if necessary.
+			if os.path.exists(str(os.getcwd()+'/info/project.json')) == True:
+				self.default_dir = str(os.getcwd()+'/particles')
+				if os.path.exists(self.default_dir) == False:
+					os.mkdir(self.default_dir)
+			else:
+				self.default_dir = os.getcwd()
 
 			self.helices_coords_line_edit.setText( os.path.join(self.default_dir, self.micrograph_name + "_boxes.txt") )
 			self.helices_images_line_edit.setText( os.path.join(self.default_dir, self.micrograph_name + "_helix."+saveext) )

--- a/programs/e2helixboxer.py
+++ b/programs/e2helixboxer.py
@@ -62,6 +62,7 @@ within a helix. Usually, all particles from a micrograph will have the same dime
 
 E2HELIXBOXER_DB = "bdb:" # used to use "bdb:e2helixboxercache#"
 
+
 def main():
 	usage = """e2helixboxer.py --gui <micrograph1> <<micrograph2> <micrograph3> ...
 	e2helixboxer.py --gui --helix-width=<width> <micrograph1> <<micrograph2> <micrograph3> ...


### PR DESCRIPTION
Currently it doesn't save to the particles folder by default, which breaks the ability to make particle sets. This checks if in a project folder, and if so, defaults to particles. Will make particles folder if it doesn't exist yet, before saving. 