### PR TITLE
Fix default box-size in e2pdb2mrc.py (Å-vs-voxel error inflates box by ~apix)

### DIFF
--- a/programs/e2pdb2mrc.py
+++ b/programs/e2pdb2mrc.py
@@ -267,7 +267,7 @@ def main():
 			boxsize=boxsizeinput
 		except:
 			boxsize=max([(amax[0]-amin[0]),(amax[1]-amin[1]),(amax[2]-amin[2])])
-			boxsize=int(1.9*boxsize+(2.0*options.res/options.apix))
+			boxsize=int(1.9*boxsize/options.apix+(2.0*options.res/options.apix))
 
 		pa=PointArray()
 		pa.read_from_pdb(args[0], lines)


### PR DESCRIPTION
## Bug
In `main()` (default summation path), when `--box` is not given, the box size
uses the bounding-box extent in Å directly as a voxel count, missing `/apix`:

```python
boxsize = max([(amax[0]-amin[0]), (amax[1]-amin[1]), (amax[2]-amin[2])])  # Å
boxsize = int(1.9*boxsize + (2.0*options.res/options.apix))              # used as voxels
```

This inflates the box by ~`apix`×.